### PR TITLE
Speed up subtractRepeated() again

### DIFF
--- a/libflatsurf/src/impl/lengths.hpp
+++ b/libflatsurf/src/impl/lengths.hpp
@@ -71,6 +71,10 @@ class Lengths {
 
   T length(intervalxt::Label) const;
   T length() const;
+  // Return whether this label is the leftmost label on a top contour.
+  bool minuendOnTop(intervalxt::Label) const;
+  // Return the component that holds this label.
+  FlowComponentState<FlatTriangulation<T>>& component(intervalxt::Label) const;
 
   std::weak_ptr<FlowDecompositionState<FlatTriangulation<T>>> state;
   std::shared_ptr<const Vertical<FlatTriangulation<T>>> vertical;


### PR DESCRIPTION
fixes #155. This now works by performing a single subtract() to
normalize the shape of the contour and then the repeated subtractions.

We could get rid of the initial subtract if we change intervalxt to
always store bottom left connections on the top. See
https://github.com/flatsurf/intervalxt/issues/96.