### PR TITLE
speed up tests

### DIFF
--- a/libflatsurf/test/Makefile.am
+++ b/libflatsurf/test/Makefile.am
@@ -4,12 +4,12 @@ TESTS = $(check_PROGRAMS)
 
 cereal_SOURCES = cereal.test.cc cereal.helpers.hpp main.cc surfaces.hpp generators/saddle_connections_generator.hpp
 chain_SOURCES = chain.test.cc main.cc
-contour_decomposition_SOURCES = contour_decomposition.test.cc main.cc surfaces.hpp generators/saddle_connections_generator.hpp generators/surface_generator.hpp
+contour_decomposition_SOURCES = contour_decomposition.test.cc main.cc surfaces.hpp generators/vertical_generator.hpp generators/surface_generator.hpp
 delaunay_SOURCES = delaunay.test.cc main.cc generators/half_edge_generator.hpp
 flat_triangulation_SOURCES = flat_triangulation.test.cc main.cc surfaces.hpp
 flat_triangulation_collapsed_SOURCES = flat_triangulation_collapsed.test.cc main.cc surfaces.hpp generators/saddle_connections_generator.hpp
 flat_triangulation_combinatorial_SOURCES = flat_triangulation_combinatorial.test.cc main.cc surfaces.hpp generators/combinatorial_surface_generator.hpp
-flow_decomposition_SOURCES = flow_decomposition.test.cc main.cc surfaces.hpp generators/saddle_connections_generator.hpp generators/surface_generator.hpp
+flow_decomposition_SOURCES = flow_decomposition.test.cc main.cc surfaces.hpp generators/vertical_generator.hpp generators/surface_generator.hpp
 half_edge_SOURCES = half_edge.test.cc main.cc
 edge_SOURCES = edge.test.cc main.cc
 permutation_SOURCES = permutation.test.cc main.cc

--- a/libflatsurf/test/contour_decomposition.test.cc
+++ b/libflatsurf/test/contour_decomposition.test.cc
@@ -42,8 +42,8 @@
 #include "../flatsurf/vector.hpp"
 #include "../flatsurf/vertical.hpp"
 
-#include "generators/saddle_connections_generator.hpp"
 #include "generators/surface_generator.hpp"
+#include "generators/vertical_generator.hpp"
 
 using boost::lexical_cast;
 using eantic::renf_class;
@@ -109,7 +109,7 @@ TEMPLATE_TEST_CASE("Connections and IET from Contour Decomposition", "[contour_d
   const auto surface = GENERATE(makeSurface<T>());
 
   GIVEN("The surface " << *surface) {
-    const auto saddleConnection = GENERATE_COPY(saddleConnections<T>(surface));
+    const auto saddleConnection = GENERATE_COPY(verticals<T>(surface));
 
     AND_GIVEN("A direction of a Saddle Connection " << saddleConnection) {
       THEN("The Contour Decomposition in that Direction can be Computed") {

--- a/libflatsurf/test/flow_decomposition.test.cc
+++ b/libflatsurf/test/flow_decomposition.test.cc
@@ -20,6 +20,8 @@
 
 #include "external/catch2/single_include/catch2/catch.hpp"
 
+#include <e-antic/renfxx.h>
+#include <gmpxx.h>
 #include <exact-real/element.hpp>
 #include <exact-real/integer_ring.hpp>
 #include <exact-real/number_field.hpp>
@@ -30,8 +32,8 @@
 #include "../flatsurf/saddle_connections.hpp"
 #include "../flatsurf/vector.hpp"
 
-#include "generators/saddle_connections_generator.hpp"
 #include "generators/surface_generator.hpp"
+#include "generators/vertical_generator.hpp"
 #include "surfaces.hpp"
 
 using eantic::renf_class;
@@ -67,11 +69,11 @@ TEMPLATE_TEST_CASE("Flow Decomposition", "[flow_decomposition]", (renf_elem_clas
   const auto surface = GENERATE(makeSurface<T>());
 
   GIVEN("The surface " << *surface) {
-    const auto saddleConnection = GENERATE_COPY(saddleConnections<T>(surface));
+    const auto vertical = GENERATE_COPY(verticals<T>(surface));
 
-    AND_GIVEN("A direction of a Saddle Connection " << saddleConnection) {
+    AND_GIVEN("A direction of a Saddle Connection " << vertical) {
       THEN("The flow decomposition in that direction can be computed") {
-        auto flowDecomposition = FlowDecomposition<FlatTriangulation<T>>(surface->clone(), saddleConnection);
+        auto flowDecomposition = FlowDecomposition<FlatTriangulation<T>>(surface->clone(), vertical);
 
         const auto area = [](const auto& decomposition) {
           T sum = T();

--- a/libflatsurf/test/generators/saddle_connections_generator.hpp
+++ b/libflatsurf/test/generators/saddle_connections_generator.hpp
@@ -23,9 +23,6 @@
 
 #include <memory>
 
-#include <e-antic/renf_elem.h>
-#include <gmpxx.h>
-
 #include "../external/catch2/single_include/catch2/catch.hpp"
 
 #include "../../flatsurf/bound.hpp"

--- a/libflatsurf/test/generators/vertical_generator.hpp
+++ b/libflatsurf/test/generators/vertical_generator.hpp
@@ -1,0 +1,82 @@
+/**********************************************************************
+ *  This file is part of flatsurf.
+ *
+ *        Copyright (C) 2020 Vincent Delecroix
+ *        Copyright (C) 2020 Julian Rüth
+ *
+ *  Flatsurf is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Flatsurf is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with flatsurf. If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************/
+
+#ifndef LIBFLATSURF_TEST_GENERATORS_VERTICAL_GENERATORS_HPP
+#define LIBFLATSURF_TEST_GENERATORS_VERTICAL_GENERATORS_HPP
+
+#include <memory>
+
+#include "../external/catch2/single_include/catch2/catch.hpp"
+
+#include "../../flatsurf/bound.hpp"
+#include "../../flatsurf/saddle_connection.hpp"
+#include "../../flatsurf/saddle_connections.hpp"
+#include "../../flatsurf/saddle_connections_iterator.hpp"
+#include "../../flatsurf/vector.hpp"
+
+namespace flatsurf::test {
+
+// Generates verticals coming from saddle connections up to a certain length.
+// This differs from the saddle connections generator in that it skips over
+// negatives of previous directions and also does not report the same direction
+// starting at a different half edge.
+template <typename T>
+class VerticalGenerator : public Catch::Generators::IGenerator<Vector<T>> {
+  std::unordered_set<Vector<T>> verticals;
+  SaddleConnections<FlatTriangulation<T>> connections;
+  typename SaddleConnections<FlatTriangulation<T>>::Iterator upcoming;
+  Vector<T> current;
+
+ public:
+  VerticalGenerator(std::shared_ptr<FlatTriangulation<T>> surface, Bound bound = Bound(3, 0)) :
+    verticals{},
+    connections(surface, bound),
+    upcoming(begin(connections)) {
+    next();
+  }
+
+  const Vector<T>& get() const override {
+    return current;
+  }
+
+  bool next() override {
+    current = *upcoming;
+
+    do {
+      ++upcoming;
+      if (upcoming == end(connections))
+        return false;
+    } while (verticals.find(*upcoming) != end(verticals) || verticals.find(-*upcoming) != end(verticals));
+
+    verticals.insert(*upcoming);
+
+    return true;
+  }
+};
+
+template <typename T>
+Catch::Generators::GeneratorWrapper<Vector<T>> verticals(std::shared_ptr<FlatTriangulation<T>> surface) {
+  return Catch::Generators::GeneratorWrapper<Vector<T>>(std::unique_ptr<Catch::Generators::IGenerator<Vector<T>>>(new VerticalGenerator<T>(surface)));
+}
+
+}  // namespace flatsurf::test
+
+#endif
+

--- a/libflatsurf/test/generators/vertical_generator.hpp
+++ b/libflatsurf/test/generators/vertical_generator.hpp
@@ -79,4 +79,3 @@ Catch::Generators::GeneratorWrapper<Vector<T>> verticals(std::shared_ptr<FlatTri
 }  // namespace flatsurf::test
 
 #endif
-


### PR DESCRIPTION
by only performing flow decompositions and such once for every vertical
direction