### PR TITLE
Bump dependency versions & fix fmt detection

### DIFF
--- a/.ci_support/linux_benchmark.yaml
+++ b/.ci_support/linux_benchmark.yaml
@@ -3,9 +3,9 @@ _python:
 action:
 - benchmark
 arb:
-- '2.17'
+- '2.18'
 boost_cpp:
-- 1.70.0
+- '1.72'
 channel_sources:
 - flatsurf,conda-forge,defaults
 channel_targets:
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - condaforge/linux-anvil-comp7
 fmt:
-- '6'
+- '7'
 gmp:
 - '6'
 job:

--- a/.ci_support/linux_coverage.yaml
+++ b/.ci_support/linux_coverage.yaml
@@ -3,9 +3,9 @@ _python:
 action:
 - coverage
 arb:
-- '2.17'
+- '2.18'
 boost_cpp:
-- 1.70.0
+- '1.72'
 channel_sources:
 - flatsurf,conda-forge,defaults
 channel_targets:
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - condaforge/linux-anvil-comp7
 fmt:
-- '6'
+- '7'
 gmp:
 - '6'
 job:

--- a/.ci_support/linux_release.yaml
+++ b/.ci_support/linux_release.yaml
@@ -7,9 +7,9 @@ action:
 - release
 - release
 arb:
-- '2.17'
+- '2.18'
 boost_cpp:
-- 1.70.0
+- '1.72'
 channel_sources:
 - flatsurf,conda-forge,defaults
 channel_targets:
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - condaforge/linux-anvil-comp7
 fmt:
-- '6'
+- '7'
 gmp:
 - '6'
 job:

--- a/.ci_support/linux_style.yaml
+++ b/.ci_support/linux_style.yaml
@@ -3,9 +3,9 @@ _python:
 action:
 - style
 arb:
-- '2.17'
+- '2.18'
 boost_cpp:
-- 1.70.0
+- '1.72'
 channel_sources:
 - flatsurf,conda-forge,defaults
 channel_targets:
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - condaforge/linux-anvil-comp7
 fmt:
-- '6'
+- '7'
 gmp:
 - '6'
 job:

--- a/.ci_support/linux_test36.yaml
+++ b/.ci_support/linux_test36.yaml
@@ -3,9 +3,9 @@ _python:
 action:
 - test
 arb:
-- '2.17'
+- '2.18'
 boost_cpp:
-- 1.70.0
+- '1.72'
 channel_sources:
 - flatsurf,conda-forge,defaults
 channel_targets:
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - condaforge/linux-anvil-comp7
 fmt:
-- '6'
+- '7'
 gmp:
 - '6'
 job:

--- a/.ci_support/linux_test37.yaml
+++ b/.ci_support/linux_test37.yaml
@@ -3,9 +3,9 @@ _python:
 action:
 - test
 arb:
-- '2.17'
+- '2.18'
 boost_cpp:
-- 1.70.0
+- '1.72'
 channel_sources:
 - flatsurf,conda-forge,defaults
 channel_targets:
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - condaforge/linux-anvil-comp7
 fmt:
-- '6'
+- '7'
 gmp:
 - '6'
 job:

--- a/.ci_support/migrations/boost172.yaml
+++ b/.ci_support/migrations/boost172.yaml
@@ -1,0 +1,12 @@
+migrator_ts: 1582183745
+__migrator:
+  kind:
+    version
+  migration_number:
+    2
+  build_number:
+    1
+boost:
+  - 1.72
+boost_cpp:
+  - 1.72

--- a/libflatsurf/configure.ac
+++ b/libflatsurf/configure.ac
@@ -40,6 +40,9 @@ AX_CXX_COMPILE_STDCXX(17)
 AC_CHECK_HEADERS([boost/type_traits.hpp], , AC_MSG_ERROR([boost headers not found]))
 
 AC_CHECK_HEADERS([fmt/format.h], , AC_MSG_ERROR([fmt headers not found]))
+AX_CXX_CHECK_LIB([fmt], [fmt::v6::getpagesize()], , [
+  AX_CXX_CHECK_LIB([fmt], [fmt::v7::getpagesize()], , [AC_MSG_ERROR([fmt library not found])], [-lfmt])
+], [-lfmt])
 
 # GMPXX does not contain anything that we can check for with AX_CXX_CHECK_LIB
 # so we just check for something from the standard library, i.e., that -lgmpxx

--- a/libflatsurf/src/Makefile.am
+++ b/libflatsurf/src/Makefile.am
@@ -168,8 +168,6 @@ libflatsurf_la_LDFLAGS += -lexactreal
 libflatsurf_la_LDFLAGS += -leanticxx -leantic
 # we build IETs with intervalxt
 libflatsurf_la_LDFLAGS += -lintervalxt
-# we use libfmt for string formatting
-libflatsurf_la_LDFLAGS += -lfmt
 
 $(builddir)/../flatsurf/local.hpp: $(srcdir)/../flatsurf/local.hpp.in Makefile
 	mkdir -p $(builddir)/../flatsurf

--- a/news/fmt.rst
+++ b/news/fmt.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* configure now allows version 6 and 7 of fmt since we do not use any version specific features

--- a/news/rever.rst
+++ b/news/rever.rst
@@ -1,0 +1,3 @@
+**Added:**
+
+* safety checks for rever deploy script

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,8 +51,8 @@ requirements:
 {%- if libflatsurf_requirements %}
     - arb
     - boost-cpp
-    - libintervalxt >=1.0.0
-    - libexactreal >=1.0.0
+    - libintervalxt >=1.0.2
+    - libexactreal >=1.1.0
     - e-antic
     - gmp
     - fmt
@@ -61,7 +61,7 @@ requirements:
     - python {{ _python }}
     - setuptools
     - gmpxxyy
-    - pyexactreal >=1.0.0
+    - pyexactreal >=1.0.2
     - cppyythonizations
 {%- endif %}
 {%- if component == "pyflatsurf" %}
@@ -90,7 +90,7 @@ requirements:
 {%- if component == "pyflatsurf" %}
     - python {{ _python }}
     - cppyy
-    - pyexactreal >=1.0.0
+    - pyexactreal >=1.0.2
     - boost-cpp
     - cppyythonizations
 {%- endif %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ requirements:
     - boost-cpp
     - libintervalxt >=1.0.0
     - libexactreal >=1.0.0
-    - e-antic >=1.0a master_1110
+    - e-antic
     - gmp
     - fmt
 {%- endif %}

--- a/rever.xsh
+++ b/rever.xsh
@@ -18,6 +18,12 @@
 #####################################################################
 
 import sys
+
+try:
+  input("Are you sure you are on the master branch which is identical to origin/master and the only pending changes are a version bump in the configure.ac of the library? [ENTER]")
+except KeyboardInterrupt:
+  sys.exit(1)
+
 sys.path.insert(0, 'recipe/snippets/rever')
 
 import dist


### PR DESCRIPTION
depends on https://github.com/flatsurf/intervalxt/pull/107 and https://github.com/flatsurf/exact-real/pull/105