### PR TITLE
Make sampling of saddle connections more stable

### DIFF
--- a/news/collinear-sample.rst
+++ b/news/collinear-sample.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* made sector selection in SaddleConnectionsSample more stable in very thin sectors


### PR DESCRIPTION
it is likely a bit slower now but it should work better with almost
collinear sector boundaries that unfortunately show up a lot in
flatsurvey.