### PR TITLE
Perform expensive assertions less frequently

### DIFF
--- a/libflatsurf/src/contour_decomposition.cc
+++ b/libflatsurf/src/contour_decomposition.cc
@@ -79,20 +79,12 @@ void ImplementationOf<ContourDecomposition<Surface>>::check(const std::vector<Pa
   {
     std::unordered_map<SaddleConnection<FlatTriangulation<T>>, int> connections;
 
-    auto track = [&](const auto& con) {
-      if (connections.find(con) == connections.end()) {
-        connections[con] = 1;
-        connections[-con] = 0;
-      } else {
-        connections[con]++;
-        CHECK(connections[con] == 1, "Each connection must show up exactly once with each sign in the perimeters of the components but " << con << " does show up " << connections[con] << " times.");
-        CHECK(connections[-con] == 1, "Each connection must show up exactly once with each sign in the perimeters of the components but " << con << " does show up " << connections[-con] << " times.");
-      }
-    };
-
     for (auto& component : decomposition)
       for (auto& connection : component)
-        track(connection);
+        connections[connection]++;
+
+    for (auto& connection : connections)
+      CHECK(connections[-connection.first] == 1, "Each connection must show up exactly once with each sign in the perimiters of the components but " << connection.first << " does show up " << connections[-connection.first] + connection.second << " times.");
   }
 
   // The total angle at each vertex has not changed

--- a/news/decomposition-check.rst
+++ b/news/decomposition-check.rst
@@ -1,0 +1,3 @@
+**Performance:**
+
+* perform assertions less frequently in `FlowDecomposition::decompose()`; these assertions made up one third of the runtime in many triangle instances.


### PR DESCRIPTION
we have not seen these fail in months, so it should be good enough to
only check when we are done with the decomposition.

fixes #227.