### PR TITLE
Do not prune decomposition of components

### DIFF
--- a/doc/news/short-circuit.rst
+++ b/doc/news/short-circuit.rst
@@ -1,0 +1,6 @@
+**Fixed:**
+
+* Do not prune decomposition as soon as a component reached the induction limit
+  in a `FlowDecomposition::decompose()`. Such a pruning would only affect the
+  local subtree and not the entire decomposition. There is (and was) no way to
+  stop the entire decomposition once a limit has been reached.

--- a/libflatsurf/src/flow_component.cc
+++ b/libflatsurf/src/flow_component.cc
@@ -52,7 +52,7 @@ using std::string;
 
 template <typename Surface>
 bool FlowComponent<Surface>::decompose(std::function<bool(const FlowComponent<Surface>&)> target, int limit) {
-  bool limitReached = false;
+  bool limitSufficed = true;
 
   const auto check = [&]() {
     auto paths = self->state->components | rx::transform([&](const auto& component) { return Path(ImplementationOf<FlowComponent<Surface>>::make(self->state, &const_cast<FlowComponentState<Surface>&>(component)).perimeter() | rx::transform([](const auto& connection) { return connection.saddleConnection(); }) | rx::to_vector()); }) | rx::to_vector();
@@ -64,7 +64,7 @@ bool FlowComponent<Surface>::decompose(std::function<bool(const FlowComponent<Su
 
     if (step.result == intervalxt::DecompositionStep::Result::LIMIT_REACHED) {
       LIBFLATSURF_ASSERTIONS(check);
-      limitReached = true;
+      limitSufficed = false;
       break;
     }
 
@@ -249,13 +249,13 @@ bool FlowComponent<Surface>::decompose(std::function<bool(const FlowComponent<Su
 
       auto component = ImplementationOf<FlowComponent>::make(self->state, &*self->state->components.rbegin());
 
-      limitReached = component.decompose(target, limit) || limitReached;
+      limitSufficed = component.decompose(target, limit) && limitSufficed;
     }
   }
 
   LIBFLATSURF_ASSERTIONS(check);
 
-  return not limitReached;
+  return limitSufficed;
 }
 
 template <typename Surface>

--- a/libflatsurf/src/flow_decomposition.cc
+++ b/libflatsurf/src/flow_decomposition.cc
@@ -82,10 +82,10 @@ const Surface& FlowDecomposition<Surface>::surface() const {
 
 template <typename Surface>
 bool FlowDecomposition<Surface>::decompose(std::function<bool(const FlowComponent<Surface>&)> target, int limit) {
-  bool targetReached = true;
+  bool limitSufficed = true;
   for (auto& component : components())
-    targetReached = component.decompose(target, limit) && targetReached;
-  return targetReached;
+    limitSufficed = component.decompose(target, limit) && limitSufficed;
+  return limitSufficed;
 }
 
 template <typename Surface>

--- a/libflatsurf/src/flow_decomposition.cc
+++ b/libflatsurf/src/flow_decomposition.cc
@@ -84,7 +84,7 @@ template <typename Surface>
 bool FlowDecomposition<Surface>::decompose(std::function<bool(const FlowComponent<Surface>&)> target, int limit) {
   bool targetReached = true;
   for (auto& component : components())
-    targetReached = targetReached && component.decompose(target, limit);
+    targetReached = component.decompose(target, limit) && targetReached;
   return targetReached;
 }
 


### PR DESCRIPTION
this came up as part of the search for undetermined IETs. If we prune
immediately when we reach a limit somewhere, we'll declare many of the
other components as "undetermined" as well, even if they are actually
evidently cylinders.