### PR TITLE
Expose CompareSlopes() in a more convenient way in Python

### DIFF
--- a/doc/news/slopes.rst
+++ b/doc/news/slopes.rst
@@ -1,0 +1,5 @@
+**Added:**
+
+* `SaddleConnections.slopes()` and `SaddleConnectionsByLength.slopes()` to
+  ignore saddle connections with repeated slopes.
+

--- a/pyflatsurf/test/saddle_connections.py
+++ b/pyflatsurf/test/saddle_connections.py
@@ -37,11 +37,23 @@ def test_square_longlong():
     # conversion to list does not work at the moment.
     # assert len(list(connections))
     assert len([1 for c in connections]) == 60
+    assert len([1 for s in connections.slopes()]) == 60
+
+def test_slopes():
+    surface = surfaces.square(flatsurf.Vector['long long'])
+    connections = surface.connections().bound(2)
+
+    # The six half edges and the connection (1, -1) and its reverse (-1, 1)
+    assert len([1 for c in connections]) == 8
+
+    # There are five slopes, -∞, -1, 0, 1, +∞.
+    assert len([1 for s in connections.slopes()]) == 5
 
 def test_L_mpq():
     surface = surfaces.L(flatsurf.Vector['mpq_class'])
     connections = surface.connections().bound(16).sector(flatsurf.HalfEdge(1))
     assert len([1 for c in connections]) == 60
+    assert len([1 for s in connections.slopes()]) == 60
 
 def test_L_with_slit_mpq():
     import cppyy


### PR DESCRIPTION
We opted for .slopes() to return saddle connections instead of vectors
for no strong reason. The scaling of the vectors might otherwise
confusing. Also, we do not win anything performance-wise by hiding that
information from the user…and the user just needs to call .vector() to
get the vector representation of the slope.