### PR TITLE
Fix bounds in saddle connection search

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "libflatsurf/src/external/sigslot"]
 	path = libflatsurf/src/external/sigslot
 	url = https://github.com/palacaze/sigslot.git
+[submodule "libflatsurf/src/external/gmpxxll"]
+	path = libflatsurf/src/external/gmpxxll
+	url = https://github.com:flatsurf/gmpxxll

--- a/.gitmodules
+++ b/.gitmodules
@@ -15,4 +15,4 @@
 	url = https://github.com/palacaze/sigslot.git
 [submodule "libflatsurf/src/external/gmpxxll"]
 	path = libflatsurf/src/external/gmpxxll
-	url = https://github.com:flatsurf/gmpxxll
+	url = https://github.com/flatsurf/gmpxxll

--- a/doc/binder/environment.yml
+++ b/doc/binder/environment.yml
@@ -5,7 +5,6 @@ channels:
   - flatsurf
   - conda-forge
 dependencies:
-  - boost-cpp
   - libflatsurf>=3.0.0
   - notebook
   - pyflatsurf>=3.0.0

--- a/doc/news/radius.rst
+++ b/doc/news/radius.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Treat search bound in saddle connection search correctly. Before the search was aborted as soon as two endpoints of an edge were outside the search radius.

--- a/libflatsurf/src/Makefile.am
+++ b/libflatsurf/src/Makefile.am
@@ -204,5 +204,7 @@ nodist_include_HEADERS = ../flatsurf/local.hpp
 EXTRA_DIST += external/sigslot/include
 # We vendor the header-only library rx-ranges
 EXTRA_DIST += external/rx-ranges/include/rx/ranges.hpp
+# We vendor our header-only library gmpxxll
+EXTRA_DIST += external/gmpxxll/gmpxxll/mpz_class.hpp
 
 CLEANFILES = ../flatsurf/local.hpp

--- a/libflatsurf/src/assert_connection.cc
+++ b/libflatsurf/src/assert_connection.cc
@@ -35,6 +35,7 @@ template <typename T>
 bool AssertConnection<T>::operator()(const SaddleConnection<FlatTriangulation<T>>& claimed) {
   if (cost > budget) {
     budget++;
+    // We ran out of gas. Assume that this saddle connection actually exists.
     return true;
   }
 
@@ -62,7 +63,7 @@ bool AssertConnection<T>::operator()(const SaddleConnection<FlatTriangulation<T>
     switch (w.ccw(v)) {
       case CCW::COLLINEAR:
         cost = steps;
-        return w == v;
+        return *it == claimed;
       case CCW::CLOCKWISE:
         it.skipSector(CCW::COUNTERCLOCKWISE);
         ccw = w;

--- a/libflatsurf/src/assert_connection.cc
+++ b/libflatsurf/src/assert_connection.cc
@@ -83,6 +83,8 @@ bool AssertConnection<T>::operator()(const SaddleConnection<FlatTriangulation<T>
     }
   }
 
+  // The above loop finished and explored all candidate saddle connections.
+  // This saddle connection does not exist in the surface.
   return false;
 }
 

--- a/libflatsurf/src/impl/assert_connection.hpp
+++ b/libflatsurf/src/impl/assert_connection.hpp
@@ -29,6 +29,9 @@ namespace flatsurf {
 template <typename T>
 class AssertConnection {
  public:
+  // Return whether this saddle connection actually exists in the surface.
+  // Also, returns ``true`` when we found that it would take an unreasonable
+  // amount of time to check.
   bool operator()(const SaddleConnection<FlatTriangulation<T>>&);
 
  private:

--- a/libflatsurf/src/impl/saddle_connections_iterator.impl.hpp
+++ b/libflatsurf/src/impl/saddle_connections_iterator.impl.hpp
@@ -46,11 +46,13 @@ class ImplementationOf<SaddleConnectionsIterator<Surface>> {
 
   enum class State {
     // The search will now cross nextEdge which starts and ends inside the search radius
-    START_FROM_INSIDE_TO_INSIDE,
+    START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS,
     // The search will now cross nextEdge which starts inside the search radius and ends outside or at the search radius
-    START_FROM_INSIDE_TO_OUTSIDE,
+    START_AT_EDGE_FROM_INSIDE_RADIUS_TO_OUTSIDE_RADIUS,
     // The search will now cross nextEdge which starts outside or at the search radius and ends inside the search radius
-    START_FROM_OUTSIDE_TO_INSIDE,
+    START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_INSIDE_RADIUS,
+    // The search will now cross nextEdge which starts and ends outside or at the search radius
+    START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS,
     OUTSIDE_SEARCH_SECTOR_COUNTERCLOCKWISE,
     OUTSIDE_SEARCH_SECTOR_CLOCKWISE,
     // The iterator has stopped at a Saddle Connection inside or at the search radius
@@ -134,6 +136,8 @@ class ImplementationOf<SaddleConnectionsIterator<Surface>> {
   Classification classifyHalfEdgeEnd();
 
   void pushStart(bool fromOutside, bool toOutside);
+  void pushStart(State current, bool toOutside);
+  void pushStart(bool fromOutside, State current);
 };
 
 template <typename Surface>

--- a/libflatsurf/src/impl/saddle_connections_iterator.impl.hpp
+++ b/libflatsurf/src/impl/saddle_connections_iterator.impl.hpp
@@ -24,6 +24,7 @@
 #include <stack>
 #include <variant>
 #include <vector>
+#include <boost/logic/tribool_fwd.hpp>
 
 #include "../../flatsurf/bound.hpp"
 #include "../../flatsurf/ccw.hpp"
@@ -45,14 +46,34 @@ class ImplementationOf<SaddleConnectionsIterator<Surface>> {
   };
 
   enum class State {
-    // The search will now cross nextEdge which starts and ends inside the search radius
-    START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS,
-    // The search will now cross nextEdge which starts inside the search radius and ends outside or at the search radius
-    START_AT_EDGE_FROM_INSIDE_RADIUS_TO_OUTSIDE_RADIUS,
-    // The search will now cross nextEdge which starts outside or at the search radius and ends inside the search radius
-    START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_INSIDE_RADIUS,
-    // The search will now cross nextEdge which starts and ends outside or at the search radius
-    START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS,
+    // The search will now cross nextEdge which starts and ends inside the
+    // search radius (or at least that's what we are assuming for simplicity.)
+    START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_INSIDE_RADIUS,
+    // The search will now cross nextEdge which starts inside the search radius
+    // (and probably also ends there but we do not know.)
+    START_AT_EDGE_STARTS_INSIDE_RADIUS,
+    // The search will now cross nextEdge which starts inside the search radius
+    // but ends outside of the search radius.
+    START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_OUTSIDE_RADIUS,
+    // The search will now cross nextEdge which ends inside the search radius
+    // but we do not know whether it also starts there.
+    START_AT_EDGE_ENDS_INSIDE_RADIUS,
+    // The search will now cross nextEdge. We don know whether it starts or
+    // ends inside the search radius.
+    START_AT_EDGE,
+    // The search will now cross nextEdge which ends outside (or at) the search
+    // radius. We do not know whether it starts inside or outside.
+    START_AT_EDGE_ENDS_OUTSIDE_RADIUS,
+    // The search will now cross nextEdge which starts outside (or at) the
+    // search radius and ends inside the search radius.
+    START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_INSIDE_RADIUS,
+    // The search will now cross nextEdge which starts outside (or at) the
+    // search radius. We do not know whether it ends inside or outside the
+    // search radius.
+    START_AT_EDGE_STARTS_OUTSIDE_RADIUS,
+    // The search will now cross nexetEdge with starts and ends outside (or at)
+    // the search radius.
+    START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_OUTSIDE_RADIUS,
     OUTSIDE_SEARCH_SECTOR_COUNTERCLOCKWISE,
     OUTSIDE_SEARCH_SECTOR_CLOCKWISE,
     // The iterator has stopped at a Saddle Connection inside or at the search radius
@@ -135,9 +156,9 @@ class ImplementationOf<SaddleConnectionsIterator<Surface>> {
 
   Classification classifyHalfEdgeEnd();
 
-  void pushStart(bool fromOutside, bool toOutside);
-  void pushStart(State current, bool toOutside);
-  void pushStart(bool fromOutside, State current);
+  void pushStart(boost::logic::tribool fromOutside, boost::logic::tribool toOutside);
+  void pushStart(State current, boost::logic::tribool toOutside);
+  void pushStart(boost::logic::tribool fromOutside, State current);
 };
 
 template <typename Surface>

--- a/libflatsurf/src/impl/saddle_connections_iterator.impl.hpp
+++ b/libflatsurf/src/impl/saddle_connections_iterator.impl.hpp
@@ -156,8 +156,16 @@ class ImplementationOf<SaddleConnectionsIterator<Surface>> {
 
   Classification classifyHalfEdgeEnd();
 
+  // Return the topmost State from the recursion stack.
+  State pop();
+
+  // Push a START_* state onto the stack.
   void pushStart(boost::logic::tribool fromOutside, boost::logic::tribool toOutside);
+
+  // Push a START_* state onto the stack.
   void pushStart(State current, boost::logic::tribool toOutside);
+
+  // Push a START_* state onto the stack.
   void pushStart(boost::logic::tribool fromOutside, State current);
 };
 

--- a/libflatsurf/src/saddle_connections_iterator.cc
+++ b/libflatsurf/src/saddle_connections_iterator.cc
@@ -24,6 +24,7 @@
 #include <type_traits>
 #include <variant>
 #include <vector>
+#include <boost/logic/tribool.hpp>
 
 #include "../flatsurf/chain.hpp"
 #include "../flatsurf/fmt.hpp"
@@ -33,6 +34,7 @@
 #include "external/gmpxxll/gmpxxll/mpz_class.hpp"
 #include "impl/saddle_connections.impl.hpp"
 #include "impl/saddle_connections_iterator.impl.hpp"
+#include "impl/quadratic_polynomial.hpp"
 #include "util/assert.ipp"
 
 namespace flatsurf {
@@ -78,7 +80,10 @@ void ImplementationOf<SaddleConnectionsIterator<Surface>>::prepareSearch() {
 
   nextEdgeEnd = (Chain<Surface>(connections.surface) += e) += nextEdge;
   state.push_back(State::END);
-  state.push_back(State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS);
+  // We assume for simplicity that the first half edge is inside the search
+  // radius for the increment() logic. If it is not, no wrong results will be
+  // reported but we could be a bit faster in such (rare) cases.
+  state.push_back(State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_INSIDE_RADIUS);
 
   // Report the half edge "e" as a saddle connection unless it is outside the
   // search scope.
@@ -125,8 +130,22 @@ bool ImplementationOf<SaddleConnectionsIterator<Surface>>::increment() {
 
   applyMoves();
 
-  const auto s = state.back();
+  auto s = state.back();
   state.pop_back();
+
+  // If we don't know anything about the next edge, we need to find out whether
+  // it has one endpoint inside/outside the search radius. Otherwise there are
+  // cases where this algorithm never stops.
+  if (s == State::START_AT_EDGE) {
+    if (connections.searchRadius) {
+      applyMoves();
+
+      if (static_cast<const Vector<T>&>(nextEdgeEnd) < *connections.searchRadius)
+        s = State::START_AT_EDGE_ENDS_INSIDE_RADIUS;
+      else
+        s = State::START_AT_EDGE_ENDS_OUTSIDE_RADIUS;
+    }
+  }
 
   switch (s) {
     case State::END:
@@ -136,36 +155,47 @@ bool ImplementationOf<SaddleConnectionsIterator<Surface>>::increment() {
         prepareSearch();
       }
       return true;
-    case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS:
+
+    // Some endpoints of nextEdge are outside the search radius. If all of
+    // the edge corresponding to nextEdgeEnd is outside the search radius, we
+    // can abort the search.
+    case State::START_AT_EDGE_ENDS_OUTSIDE_RADIUS:
+    case State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS:
+    case State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_OUTSIDE_RADIUS:
       LIBFLATSURF_ASSERT(connections.searchRadius, "If no search radius has been specified, the endpoints cannot be beyond the search radius.");
       
-      applyMoves();
-      // The endpoints of nextEdgeEnd are outside the search radius. If all of
-      // the edge corresponding to nextEdgeEnd is outside the search radius, we
-      // can abort the search.
+      // We write this edge as p + λe. Then it is completely outside the search
+      // radius if |p + λe|² - R² > 0 for all λ in [0, 1].
+      // Note that there was no relevant performance gain in treating the cases
+      // where only one endpoint is known to be outside the search radius
+      // differently.
       {
-        // We compute the distance of the origin to the edge we are about to
-        // cross. We use the usual formula, obtaining the distance from the
-        // height of the triangle formed by the origin and the endpoints of the
-        // edge.
-        const Vector<T> edge = connections.surface->fromHalfEdge(nextEdge);
-        const Vector<T> edgeEnd = nextEdgeEnd;
+        applyMoves();
+        const Vector<T>& edge = connections.surface->fromHalfEdge(-nextEdge);
+        const Vector<T>& edgeEnd = nextEdgeEnd;
 
-        using S = std::conditional_t<std::is_same_v<T, long long>, gmpxxll::mpz_class, T>;
-        
-        S base2height2 = edge.x() * edgeEnd.y() - edge.y() * edgeEnd.x();
-        base2height2 *= base2height2;
+        T R2;
+        if constexpr (std::is_same_v<T, long long>) {
+          R2 = gmpxxll::mpz_class((*connections.searchRadius).squared()).get_sll();
+        } else {
+          R2 = T((*connections.searchRadius).squared());
+        }
 
-        mpz_class base2radius2 = Bound::upper(edge).squared() * (*connections.searchRadius).squared();
-
-        // We abort the search when height² ≥ radius² i.e., when base²·height² ≥ base²·radius².
-        if (base2height2 >= base2radius2)
+        if (QuadraticPolynomial<T>(
+          edge.x() * edge.x() + edge.y() * edge.y(),
+          2 * edgeEnd.x() * edge.x() + 2 * edgeEnd.y() * edge.y(),
+          edgeEnd.x() * edgeEnd.x() + edgeEnd.y() * edgeEnd.y() - R2).positive())
           return false;
       }
       [[fallthrough]];
-    case State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS:
-    case State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_OUTSIDE_RADIUS:
-    case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_INSIDE_RADIUS:
+    
+    // Some endpoint of nextEdge is inside the search radius. We cross over
+    // this edge and search for saddle connections.
+    case State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_INSIDE_RADIUS:
+    case State::START_AT_EDGE_STARTS_INSIDE_RADIUS:
+    case State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_OUTSIDE_RADIUS:
+    case State::START_AT_EDGE_ENDS_INSIDE_RADIUS:
+    case State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_INSIDE_RADIUS:
       moves.push_back(Move::GOTO_OTHER_FACE);
 
       if (onBoundary()) {
@@ -177,8 +207,6 @@ bool ImplementationOf<SaddleConnectionsIterator<Surface>>::increment() {
 
       switch (classifyHalfEdgeEnd()) {
         case Classification::OUTSIDE_SEARCH_SECTOR_CLOCKWISE: {
-          const bool nothingBeyondThisVertex = connections.searchRadius && !(nextEdgeEnd < *connections.searchRadius);
-
           // This vertex is outside of the search sector on the
           // clockwise side, we skip the clockwise sector in the recursive
           // search and recurse into the counterclockwise sector.
@@ -186,18 +214,26 @@ bool ImplementationOf<SaddleConnectionsIterator<Surface>>::increment() {
 
           state.push_back(State::OUTSIDE_SEARCH_SECTOR_CLOCKWISE);
 
-          pushStart(nothingBeyondThisVertex, s);
+          // When crossing over this edge, we (often) already know whether one
+          // of its endpoints is inside or outside the search radius; that's
+          // encoded in s. Now that we just performed a classifyHalfEdgeEnd()
+          // it is cheap to also ask whether we are below the search radius
+          // with the other end point.
+          pushStart(connections.searchRadius && !(nextEdgeEnd < *connections.searchRadius), s);
 
           return false;
         }
         case Classification::OUTSIDE_SEARCH_SECTOR_COUNTERCLOCKWISE: {
-          const bool nothingBeyondThisVertex = connections.searchRadius && !(nextEdgeEnd < *connections.searchRadius);
-
           // Similarly, we skip the counterclockwise sector (but only after
           // we visited the clockwise one.)
           state.push_back(State::OUTSIDE_SEARCH_SECTOR_COUNTERCLOCKWISE);
-
-          pushStart(s, nothingBeyondThisVertex);
+          
+          // In parallel to the previous case, we could ask cheaply whether one
+          // end point is still within the search radius. I.e., perform this call:
+          // pushStart(s, connections.searchRadius && !(nextEdgeEnd < *connections.searchRadius));
+          // However, it is beneficial to only perform this call in one of
+          // these branches as the check does not come entirely for free.
+          pushStart(s, {boost::logic::indeterminate});
 
           return false;
         }
@@ -294,10 +330,15 @@ void ImplementationOf<SaddleConnectionsIterator<Surface>>::skipSector(CCW sector
         // Go directly to the second sector by skipping the recursive call,
         // i.e., the START.
         switch (state.back()) {
-          case State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS:
-          case State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_OUTSIDE_RADIUS:
-          case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_INSIDE_RADIUS:
-          case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS:
+          case State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_INSIDE_RADIUS:
+          case State::START_AT_EDGE_STARTS_INSIDE_RADIUS:
+          case State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_OUTSIDE_RADIUS:
+          case State::START_AT_EDGE_ENDS_INSIDE_RADIUS:
+          case State::START_AT_EDGE:
+          case State::START_AT_EDGE_ENDS_OUTSIDE_RADIUS:
+          case State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_INSIDE_RADIUS:
+          case State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS:
+          case State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_OUTSIDE_RADIUS:
             state.pop_back();
             break;
           default:
@@ -313,10 +354,15 @@ void ImplementationOf<SaddleConnectionsIterator<Surface>>::skipSector(CCW sector
         }
 
         switch (unchanged.top()) {
-          case State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS:
-          case State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_OUTSIDE_RADIUS:
-          case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_INSIDE_RADIUS:
-          case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS:
+          case State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_INSIDE_RADIUS:
+          case State::START_AT_EDGE_STARTS_INSIDE_RADIUS:
+          case State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_OUTSIDE_RADIUS:
+          case State::START_AT_EDGE_ENDS_INSIDE_RADIUS:
+          case State::START_AT_EDGE:
+          case State::START_AT_EDGE_ENDS_OUTSIDE_RADIUS:
+          case State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_INSIDE_RADIUS:
+          case State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS:
+          case State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_OUTSIDE_RADIUS:
             unchanged.pop();
           default:
             break;
@@ -328,10 +374,15 @@ void ImplementationOf<SaddleConnectionsIterator<Surface>>::skipSector(CCW sector
         }
       }
       break;
-    case State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS:
-    case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_INSIDE_RADIUS:
-    case State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_OUTSIDE_RADIUS:
-    case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS:
+    case State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_INSIDE_RADIUS:
+    case State::START_AT_EDGE_STARTS_INSIDE_RADIUS:
+    case State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_OUTSIDE_RADIUS:
+    case State::START_AT_EDGE_ENDS_INSIDE_RADIUS:
+    case State::START_AT_EDGE:
+    case State::START_AT_EDGE_ENDS_OUTSIDE_RADIUS:
+    case State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_INSIDE_RADIUS:
+    case State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS:
+    case State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_OUTSIDE_RADIUS:
       if (state.size() == 2) {
         if (sector == CCW::COUNTERCLOCKWISE) {
           // We are in the initial state, the reported saddle connection is on
@@ -459,44 +510,68 @@ typename ImplementationOf<SaddleConnectionsIterator<Surface>>::Classification Im
 }
 
 template <typename Surface>
-void ImplementationOf<SaddleConnectionsIterator<Surface>>::pushStart(bool fromOutside, State current) {
+void ImplementationOf<SaddleConnectionsIterator<Surface>>::pushStart(boost::logic::tribool fromOutside, State current) {
   switch (current) {
-    case State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_OUTSIDE_RADIUS:
-    case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS:
+    case State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_INSIDE_RADIUS:
+    case State::START_AT_EDGE_ENDS_INSIDE_RADIUS:
+    case State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_INSIDE_RADIUS:
+      pushStart(fromOutside, false);
+      return;
+    case State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_OUTSIDE_RADIUS:
+    case State::START_AT_EDGE_ENDS_OUTSIDE_RADIUS:
+    case State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_OUTSIDE_RADIUS:
       pushStart(fromOutside, true);
       return;
     default:
-      pushStart(fromOutside, false);
+      pushStart(fromOutside, {boost::logic::indeterminate});
       return;
   }
 }
 
 template <typename Surface>
-void ImplementationOf<SaddleConnectionsIterator<Surface>>::pushStart(State current, bool toOutside) {
+void ImplementationOf<SaddleConnectionsIterator<Surface>>::pushStart(State current, boost::logic::tribool toOutside) {
   switch (current) {
-    case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_INSIDE_RADIUS:
-    case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS:
+    case State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_INSIDE_RADIUS:
+    case State::START_AT_EDGE_STARTS_INSIDE_RADIUS:
+    case State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_OUTSIDE_RADIUS:
+      pushStart(false, toOutside);
+      return;
+    case State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_INSIDE_RADIUS:
+    case State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS:
+    case State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_OUTSIDE_RADIUS:
       pushStart(true, toOutside);
       return;
     default:
-      pushStart(false, toOutside);
+      pushStart({boost::logic::indeterminate}, toOutside);
       return;
   }
 }
 
 template <typename Surface>
-void ImplementationOf<SaddleConnectionsIterator<Surface>>::pushStart(bool fromOutside, bool toOutside) {
+void ImplementationOf<SaddleConnectionsIterator<Surface>>::pushStart(boost::logic::tribool fromOutside, boost::logic::tribool toOutside) {
   if (fromOutside) {
     if (toOutside) {
-      state.push_back(State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS);
+      state.push_back(State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_OUTSIDE_RADIUS);
+    } else if (!toOutside) {
+      state.push_back(State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_INSIDE_RADIUS);
     } else {
-      state.push_back(State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_INSIDE_RADIUS);
+      state.push_back(State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS);
+    }
+  } else if (!fromOutside) {
+    if (toOutside) {
+      state.push_back(State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_OUTSIDE_RADIUS);
+    } else if (!toOutside) {
+      state.push_back(State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_INSIDE_RADIUS);
+    } else {
+      state.push_back(State::START_AT_EDGE_STARTS_INSIDE_RADIUS);
     }
   } else {
     if (toOutside) {
-      state.push_back(State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_OUTSIDE_RADIUS);
+      state.push_back(State::START_AT_EDGE_ENDS_OUTSIDE_RADIUS);
+    } else if (!toOutside) {
+      state.push_back(State::START_AT_EDGE_ENDS_INSIDE_RADIUS);
     } else {
-      state.push_back(State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS);
+      state.push_back(State::START_AT_EDGE);
     }
   }
 }
@@ -526,6 +601,7 @@ void SaddleConnectionsIterator<Surface>::skipSector(CCW ccw) {
 
 template <typename Surface>
 std::optional<HalfEdge> SaddleConnectionsIterator<Surface>::incrementWithCrossings() {
+  using Implementation = ImplementationOf<SaddleConnectionsIterator<Surface>>;
   LIBFLATSURF_ASSERT(self->sector != self->end, "iterator is at end()");
 
   while (true) {
@@ -533,10 +609,14 @@ std::optional<HalfEdge> SaddleConnectionsIterator<Surface>::incrementWithCrossin
       return std::nullopt;
     } else
       switch (self->state.back()) {
-        case ImplementationOf<SaddleConnectionsIterator>::State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS:
-        case ImplementationOf<SaddleConnectionsIterator>::State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_OUTSIDE_RADIUS:
-        case ImplementationOf<SaddleConnectionsIterator>::State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_INSIDE_RADIUS:
-        case ImplementationOf<SaddleConnectionsIterator>::State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS: {
+        case Implementation::State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_INSIDE_RADIUS:
+        case Implementation::State::START_AT_EDGE_STARTS_INSIDE_RADIUS:
+        case Implementation::State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_OUTSIDE_RADIUS:
+        case Implementation::State::START_AT_EDGE_ENDS_INSIDE_RADIUS:
+        case Implementation::State::START_AT_EDGE_ENDS_OUTSIDE_RADIUS:
+        case Implementation::State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_INSIDE_RADIUS:
+        case Implementation::State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS:
+        case Implementation::State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_OUTSIDE_RADIUS: {
           self->applyMoves();
           const auto ret = self->nextEdge;
           self->increment();
@@ -555,7 +635,7 @@ const SaddleConnection<Surface>& SaddleConnectionsIterator<Surface>::dereference
   LIBFLATSURF_ASSERT(self->sector != self->end, "iterator is at end()");
 
   switch (self->state.back()) {
-    case ImplementationOf<SaddleConnectionsIterator>::State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS:
+    case ImplementationOf<SaddleConnectionsIterator>::State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_INSIDE_RADIUS:
       // This makes the first reported connection work: It is not nextEdgeEnd but the sector boundary.
       self->connection = SaddleConnection(*self->connections.surface, self->sector->source);
       break;
@@ -582,14 +662,22 @@ std::ostream& operator<<(std::ostream& os, const SaddleConnectionsIterator<Surfa
   } else {
     return os << fmt::format("Iterator(sector={}, nextEdge={}, nextEdgeEnd={}, stack=[{}])", self.self->sector->source, self.self->nextEdge, static_cast<Vector<T>>(self.self->nextEdgeEnd), fmt::join(self.self->state | rx::transform([](const auto& state) {
       switch (state) {
-        case Implementation::State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS:
-          return "START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS";
-        case Implementation::State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_OUTSIDE_RADIUS:
-          return "START_AT_EDGE_FROM_INSIDE_RADIUS_TO_OUTSIDE_RADIUS";
-        case Implementation::State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_INSIDE_RADIUS:
-          return "START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_INSIDE_RADIUS";
-        case Implementation::State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS:
-          return "START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS";
+        case Implementation::State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_INSIDE_RADIUS:
+          return "START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_INSIDE_RADIUS";
+        case Implementation::State::START_AT_EDGE_STARTS_INSIDE_RADIUS:
+          return "START_AT_EDGE_STARTS_INSIDE_RADIUS";
+        case Implementation::State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_OUTSIDE_RADIUS:
+          return "START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_OUTSIDE_RADIUS";
+        case Implementation::State::START_AT_EDGE_ENDS_INSIDE_RADIUS:
+          return "START_AT_EDGE_ENDS_INSIDE_RADIUS";
+        case Implementation::State::START_AT_EDGE_ENDS_OUTSIDE_RADIUS:
+          return "START_AT_EDGE_ENDS_OUTSIDE_RADIUS";
+        case Implementation::State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_INSIDE_RADIUS:
+          return "START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_INSIDE_RADIUS";
+        case Implementation::State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS:
+          return "START_AT_EDGE_STARTS_OUTSIDE_RADIUS";
+        case Implementation::State::START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_OUTSIDE_RADIUS:
+          return "START_AT_EDGE_STARTS_OUTSIDE_RADIUS_ENDS_OUTSIDE_RADIUS";
         case Implementation::State::OUTSIDE_SEARCH_SECTOR_COUNTERCLOCKWISE:
           return "OUTSIDE_SEARCH_SECTOR_COUNTERCLOCKWISE";
         case Implementation::State::OUTSIDE_SEARCH_SECTOR_CLOCKWISE:

--- a/libflatsurf/src/saddle_connections_iterator.cc
+++ b/libflatsurf/src/saddle_connections_iterator.cc
@@ -80,10 +80,7 @@ void ImplementationOf<SaddleConnectionsIterator<Surface>>::prepareSearch() {
 
   nextEdgeEnd = (Chain<Surface>(connections.surface) += e) += nextEdge;
   state.push_back(State::END);
-  // We assume for simplicity that the first half edge is inside the search
-  // radius for the increment() logic. If it is not, no wrong results will be
-  // reported but we could be a bit faster in such (rare) cases.
-  state.push_back(State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_INSIDE_RADIUS);
+  state.push_back(State::START_AT_EDGE);
 
   // Report the half edge "e" as a saddle connection unless it is outside the
   // search scope.
@@ -635,7 +632,7 @@ const SaddleConnection<Surface>& SaddleConnectionsIterator<Surface>::dereference
   LIBFLATSURF_ASSERT(self->sector != self->end, "iterator is at end()");
 
   switch (self->state.back()) {
-    case ImplementationOf<SaddleConnectionsIterator>::State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_INSIDE_RADIUS:
+    case ImplementationOf<SaddleConnectionsIterator>::State::START_AT_EDGE:
       // This makes the first reported connection work: It is not nextEdgeEnd but the sector boundary.
       self->connection = SaddleConnection(*self->connections.surface, self->sector->source);
       break;

--- a/libflatsurf/src/saddle_connections_iterator.cc
+++ b/libflatsurf/src/saddle_connections_iterator.cc
@@ -120,13 +120,7 @@ CCW ImplementationOf<SaddleConnectionsIterator<Surface>>::ccw(const Boundary& lh
 }
 
 template <typename Surface>
-bool ImplementationOf<SaddleConnectionsIterator<Surface>>::increment() {
-  assert(state.size());
-  assert(sector != end);
-  assert(ccw(boundary[0], boundary[1]) != CCW::CLOCKWISE);
-
-  applyMoves();
-
+typename ImplementationOf<SaddleConnectionsIterator<Surface>>::State ImplementationOf<SaddleConnectionsIterator<Surface>>::pop() {
   auto s = state.back();
   state.pop_back();
 
@@ -143,6 +137,17 @@ bool ImplementationOf<SaddleConnectionsIterator<Surface>>::increment() {
         s = State::START_AT_EDGE_ENDS_OUTSIDE_RADIUS;
     }
   }
+
+  return s;
+}
+
+template <typename Surface>
+bool ImplementationOf<SaddleConnectionsIterator<Surface>>::increment() {
+  assert(state.size());
+  assert(sector != end);
+  assert(ccw(boundary[0], boundary[1]) != CCW::CLOCKWISE);
+
+  const auto s = pop();
 
   switch (s) {
     case State::END:
@@ -188,6 +193,7 @@ bool ImplementationOf<SaddleConnectionsIterator<Surface>>::increment() {
     
     // Some endpoint of nextEdge is inside the search radius. We cross over
     // this edge and search for saddle connections.
+    case State::START_AT_EDGE:
     case State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_INSIDE_RADIUS:
     case State::START_AT_EDGE_STARTS_INSIDE_RADIUS:
     case State::START_AT_EDGE_STARTS_INSIDE_RADIUS_ENDS_OUTSIDE_RADIUS:

--- a/libflatsurf/src/saddle_connections_iterator.cc
+++ b/libflatsurf/src/saddle_connections_iterator.cc
@@ -21,6 +21,7 @@
 
 #include <exact-real/arb.hpp>
 #include <optional>
+#include <type_traits>
 #include <variant>
 #include <vector>
 
@@ -29,6 +30,7 @@
 #include "../flatsurf/saddle_connection.hpp"
 #include "../flatsurf/vector.hpp"
 #include "external/rx-ranges/include/rx/ranges.hpp"
+#include "external/gmpxxll/gmpxxll/mpz_class.hpp"
 #include "impl/saddle_connections.impl.hpp"
 #include "impl/saddle_connections_iterator.impl.hpp"
 #include "util/assert.ipp"
@@ -76,7 +78,7 @@ void ImplementationOf<SaddleConnectionsIterator<Surface>>::prepareSearch() {
 
   nextEdgeEnd = (Chain<Surface>(connections.surface) += e) += nextEdge;
   state.push_back(State::END);
-  state.push_back(State::START_FROM_INSIDE_TO_INSIDE);
+  state.push_back(State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS);
 
   // Report the half edge "e" as a saddle connection unless it is outside the
   // search scope.
@@ -125,6 +127,7 @@ bool ImplementationOf<SaddleConnectionsIterator<Surface>>::increment() {
 
   const auto s = state.back();
   state.pop_back();
+
   switch (s) {
     case State::END:
       applyMoves();
@@ -133,9 +136,36 @@ bool ImplementationOf<SaddleConnectionsIterator<Surface>>::increment() {
         prepareSearch();
       }
       return true;
-    case State::START_FROM_INSIDE_TO_INSIDE:
-    case State::START_FROM_INSIDE_TO_OUTSIDE:
-    case State::START_FROM_OUTSIDE_TO_INSIDE:
+    case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS:
+      LIBFLATSURF_ASSERT(connections.searchRadius, "If no search radius has been specified, the endpoints cannot be beyond the search radius.");
+      
+      applyMoves();
+      // The endpoints of nextEdgeEnd are outside the search radius. If all of
+      // the edge corresponding to nextEdgeEnd is outside the search radius, we
+      // can abort the search.
+      {
+        // We compute the distance of the origin to the edge we are about to
+        // cross. We use the usual formula, obtaining the distance from the
+        // height of the triangle formed by the origin and the endpoints of the
+        // edge.
+        const Vector<T> edge = connections.surface->fromHalfEdge(nextEdge);
+        const Vector<T> edgeEnd = nextEdgeEnd;
+
+        using S = std::conditional_t<std::is_same_v<T, long long>, gmpxxll::mpz_class, T>;
+        
+        S base2height2 = edge.x() * edgeEnd.y() - edge.y() * edgeEnd.x();
+        base2height2 *= base2height2;
+
+        mpz_class base2radius2 = Bound::upper(edge).squared() * (*connections.searchRadius).squared();
+
+        // We abort the search when height² ≥ radius² i.e., when base²·height² ≥ base²·radius².
+        if (base2height2 >= base2radius2)
+          return false;
+      }
+      [[fallthrough]];
+    case State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS:
+    case State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_OUTSIDE_RADIUS:
+    case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_INSIDE_RADIUS:
       moves.push_back(Move::GOTO_OTHER_FACE);
 
       if (onBoundary()) {
@@ -156,7 +186,7 @@ bool ImplementationOf<SaddleConnectionsIterator<Surface>>::increment() {
 
           state.push_back(State::OUTSIDE_SEARCH_SECTOR_CLOCKWISE);
 
-          pushStart(nothingBeyondThisVertex, s == State::START_FROM_INSIDE_TO_OUTSIDE);
+          pushStart(nothingBeyondThisVertex, s);
 
           return false;
         }
@@ -167,7 +197,7 @@ bool ImplementationOf<SaddleConnectionsIterator<Surface>>::increment() {
           // we visited the clockwise one.)
           state.push_back(State::OUTSIDE_SEARCH_SECTOR_COUNTERCLOCKWISE);
 
-          pushStart(s == State::START_FROM_OUTSIDE_TO_INSIDE, nothingBeyondThisVertex);
+          pushStart(s, nothingBeyondThisVertex);
 
           return false;
         }
@@ -177,9 +207,9 @@ bool ImplementationOf<SaddleConnectionsIterator<Surface>>::increment() {
           // Prepare the recursive descent into the two half edges attached
           // to this vertex.
           state.push_back(State::SADDLE_CONNECTION_FOUND_SEARCHING_SECOND);
-          pushStart(beyondRadius, s == State::START_FROM_INSIDE_TO_OUTSIDE);
+          pushStart(beyondRadius, s);
           state.push_back(State::SADDLE_CONNECTION_FOUND_SEARCHING_FIRST);
-          pushStart(s == State::START_FROM_OUTSIDE_TO_INSIDE, beyondRadius);
+          pushStart(s, beyondRadius);
 
           // Shrink the search sector for the clockwise descent.
           if (std::holds_alternative<Chain<Surface>>(boundary[1]) || std::get<Vector<T>>(boundary[1]).ccw(nextEdgeEnd) != CCW::COUNTERCLOCKWISE) {
@@ -264,9 +294,10 @@ void ImplementationOf<SaddleConnectionsIterator<Surface>>::skipSector(CCW sector
         // Go directly to the second sector by skipping the recursive call,
         // i.e., the START.
         switch (state.back()) {
-          case State::START_FROM_INSIDE_TO_INSIDE:
-          case State::START_FROM_INSIDE_TO_OUTSIDE:
-          case State::START_FROM_OUTSIDE_TO_INSIDE:
+          case State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS:
+          case State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_OUTSIDE_RADIUS:
+          case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_INSIDE_RADIUS:
+          case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS:
             state.pop_back();
             break;
           default:
@@ -282,9 +313,10 @@ void ImplementationOf<SaddleConnectionsIterator<Surface>>::skipSector(CCW sector
         }
 
         switch (unchanged.top()) {
-          case State::START_FROM_INSIDE_TO_INSIDE:
-          case State::START_FROM_INSIDE_TO_OUTSIDE:
-          case State::START_FROM_OUTSIDE_TO_INSIDE:
+          case State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS:
+          case State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_OUTSIDE_RADIUS:
+          case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_INSIDE_RADIUS:
+          case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS:
             unchanged.pop();
           default:
             break;
@@ -296,9 +328,10 @@ void ImplementationOf<SaddleConnectionsIterator<Surface>>::skipSector(CCW sector
         }
       }
       break;
-    case State::START_FROM_INSIDE_TO_INSIDE:
-    case State::START_FROM_OUTSIDE_TO_INSIDE:
-    case State::START_FROM_INSIDE_TO_OUTSIDE:
+    case State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS:
+    case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_INSIDE_RADIUS:
+    case State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_OUTSIDE_RADIUS:
+    case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS:
       if (state.size() == 2) {
         if (sector == CCW::COUNTERCLOCKWISE) {
           // We are in the initial state, the reported saddle connection is on
@@ -426,18 +459,44 @@ typename ImplementationOf<SaddleConnectionsIterator<Surface>>::Classification Im
 }
 
 template <typename Surface>
+void ImplementationOf<SaddleConnectionsIterator<Surface>>::pushStart(bool fromOutside, State current) {
+  switch (current) {
+    case State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_OUTSIDE_RADIUS:
+    case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS:
+      pushStart(fromOutside, true);
+      return;
+    default:
+      pushStart(fromOutside, false);
+      return;
+  }
+}
+
+template <typename Surface>
+void ImplementationOf<SaddleConnectionsIterator<Surface>>::pushStart(State current, bool toOutside) {
+  switch (current) {
+    case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_INSIDE_RADIUS:
+    case State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS:
+      pushStart(true, toOutside);
+      return;
+    default:
+      pushStart(false, toOutside);
+      return;
+  }
+}
+
+template <typename Surface>
 void ImplementationOf<SaddleConnectionsIterator<Surface>>::pushStart(bool fromOutside, bool toOutside) {
   if (fromOutside) {
     if (toOutside) {
-      ;
+      state.push_back(State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS);
     } else {
-      state.push_back(State::START_FROM_OUTSIDE_TO_INSIDE);
+      state.push_back(State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_INSIDE_RADIUS);
     }
   } else {
     if (toOutside) {
-      state.push_back(State::START_FROM_INSIDE_TO_OUTSIDE);
+      state.push_back(State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_OUTSIDE_RADIUS);
     } else {
-      state.push_back(State::START_FROM_INSIDE_TO_INSIDE);
+      state.push_back(State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS);
     }
   }
 }
@@ -474,9 +533,10 @@ std::optional<HalfEdge> SaddleConnectionsIterator<Surface>::incrementWithCrossin
       return std::nullopt;
     } else
       switch (self->state.back()) {
-        case ImplementationOf<SaddleConnectionsIterator>::State::START_FROM_INSIDE_TO_INSIDE:
-        case ImplementationOf<SaddleConnectionsIterator>::State::START_FROM_INSIDE_TO_OUTSIDE:
-        case ImplementationOf<SaddleConnectionsIterator>::State::START_FROM_OUTSIDE_TO_INSIDE: {
+        case ImplementationOf<SaddleConnectionsIterator>::State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS:
+        case ImplementationOf<SaddleConnectionsIterator>::State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_OUTSIDE_RADIUS:
+        case ImplementationOf<SaddleConnectionsIterator>::State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_INSIDE_RADIUS:
+        case ImplementationOf<SaddleConnectionsIterator>::State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS: {
           self->applyMoves();
           const auto ret = self->nextEdge;
           self->increment();
@@ -495,7 +555,7 @@ const SaddleConnection<Surface>& SaddleConnectionsIterator<Surface>::dereference
   LIBFLATSURF_ASSERT(self->sector != self->end, "iterator is at end()");
 
   switch (self->state.back()) {
-    case ImplementationOf<SaddleConnectionsIterator>::State::START_FROM_INSIDE_TO_INSIDE:
+    case ImplementationOf<SaddleConnectionsIterator>::State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS:
       // This makes the first reported connection work: It is not nextEdgeEnd but the sector boundary.
       self->connection = SaddleConnection(*self->connections.surface, self->sector->source);
       break;
@@ -522,12 +582,14 @@ std::ostream& operator<<(std::ostream& os, const SaddleConnectionsIterator<Surfa
   } else {
     return os << fmt::format("Iterator(sector={}, nextEdge={}, nextEdgeEnd={}, stack=[{}])", self.self->sector->source, self.self->nextEdge, static_cast<Vector<T>>(self.self->nextEdgeEnd), fmt::join(self.self->state | rx::transform([](const auto& state) {
       switch (state) {
-        case Implementation::State::START_FROM_INSIDE_TO_INSIDE:
-          return "START_FROM_INSIDE_TO_INSIDE";
-        case Implementation::State::START_FROM_INSIDE_TO_OUTSIDE:
-          return "START_FROM_INSIDE_TO_OUTSIDE";
-        case Implementation::State::START_FROM_OUTSIDE_TO_INSIDE:
-          return "START_FROM_OUTSIDE_TO_INSIDE";
+        case Implementation::State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS:
+          return "START_AT_EDGE_FROM_INSIDE_RADIUS_TO_INSIDE_RADIUS";
+        case Implementation::State::START_AT_EDGE_FROM_INSIDE_RADIUS_TO_OUTSIDE_RADIUS:
+          return "START_AT_EDGE_FROM_INSIDE_RADIUS_TO_OUTSIDE_RADIUS";
+        case Implementation::State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_INSIDE_RADIUS:
+          return "START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_INSIDE_RADIUS";
+        case Implementation::State::START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS:
+          return "START_AT_EDGE_FROM_OUTSIDE_RADIUS_TO_OUTSIDE_RADIUS";
         case Implementation::State::OUTSIDE_SEARCH_SECTOR_COUNTERCLOCKWISE:
           return "OUTSIDE_SEARCH_SECTOR_COUNTERCLOCKWISE";
         case Implementation::State::OUTSIDE_SEARCH_SECTOR_CLOCKWISE:

--- a/libflatsurf/src/tracked.cc
+++ b/libflatsurf/src/tracked.cc
@@ -213,7 +213,11 @@ Tracked<T>& Tracked<T>::operator=(T&& value) {
 template <typename T>
 std::ostream& operator<<(std::ostream& os, const Tracked<T>& self) {
   if constexpr (is_optional<T>::value) {
-    return os << *static_cast<const T&>(self);
+    if (static_cast<const T&>(self)) {
+      return os << *static_cast<const T&>(self);
+    } else {
+      return os << "{}";
+    }
   } else {
     return os << static_cast<const T&>(self);
   }

--- a/libflatsurf/test/generators/combinatorial_surface_generator.hpp
+++ b/libflatsurf/test/generators/combinatorial_surface_generator.hpp
@@ -38,6 +38,7 @@ class CombinatorialSurfaceGenerator : public Catch::Generators::IGenerator<std::
     L,
     _125,
     _1221,
+    _22313,
     HEXAGON,
     HEPTAGON_L,
     LAST = HEPTAGON_L
@@ -56,6 +57,8 @@ class CombinatorialSurfaceGenerator : public Catch::Generators::IGenerator<std::
         return make125Combinatorial();
       case Surface::_1221:
         return make1221Combinatorial();
+      case Surface::_22313:
+        return make22313Combinatorial();
       case Surface::HEXAGON:
         return makeHexagonCombinatorial();
       case Surface::HEPTAGON_L:

--- a/libflatsurf/test/generators/surface_generator.hpp
+++ b/libflatsurf/test/generators/surface_generator.hpp
@@ -49,6 +49,7 @@ class SurfaceGenerator : public Catch::Generators::IGenerator<std::tuple<std::st
     _125,
     _1221,
     _1234,
+    _22313,
     _235,
     HEXAGON,
     OCTAGON,
@@ -140,6 +141,13 @@ class SurfaceGenerator : public Catch::Generators::IGenerator<std::tuple<std::st
         if constexpr (hasFractions<T> && hasNumberFieldElements<T>) {
           name = "(1, 2, 3, 4)";
           value = make1234<R2>();
+        } else
+          value = nullptr;
+        return;
+      case Surface::_22313:
+        if constexpr (hasNumberFieldElements<T>) {
+          name = "(2, 2, 3, 13)";
+          value = make22313<R2>();
         } else
           value = nullptr;
         return;

--- a/libflatsurf/test/saddle_connections.test.cc
+++ b/libflatsurf/test/saddle_connections.test.cc
@@ -46,6 +46,23 @@
 
 namespace flatsurf::test {
 
+TEMPLATE_TEST_CASE("Saddle Connections on a (2, 2, 3, 13) Quadrilateral", "[saddle_connections]", (renf_elem_class), (exactreal::Element<exactreal::NumberField>)) {
+  using T = TestType;
+  using R2 = Vector<T>;
+  auto surface = make22313<R2>();
+
+  GIVEN("The Quadrilateral " << *surface) {
+    // We check that this saddle connection from -3 to 6 is found; verifying
+    // that a bug that appeared in early 2021 has been fixed.
+    const auto search = Vector<T>(-L_->gen() + 2, 0);
+    // The connections starting at edge -3 of length at most sqrt(7)
+    const auto connections = SaddleConnections<FlatTriangulation<T>>(*surface).sector(-3).bound(Bound::upper(search));
+    REQUIRE(std::find_if(begin(connections), end(connections), [&](const auto& connection) {
+      return connection.vector() == search;
+    }) != end(connections));
+  }
+}
+
 TEMPLATE_TEST_CASE("Saddle Connections on a Torus", "[saddle_connections]", (long long), (mpq_class), (renf_elem_class), (exactreal::Element<exactreal::IntegerRing>), (exactreal::Element<exactreal::NumberField>)) {
   using R2 = Vector<TestType>;
   auto square = makeSquare<R2>();

--- a/libflatsurf/test/saddle_connections.test.cc
+++ b/libflatsurf/test/saddle_connections.test.cc
@@ -46,23 +46,6 @@
 
 namespace flatsurf::test {
 
-TEMPLATE_TEST_CASE("Saddle Connections on a (2, 2, 3, 13) Quadrilateral", "[saddle_connections]", (renf_elem_class), (exactreal::Element<exactreal::NumberField>)) {
-  using T = TestType;
-  using R2 = Vector<T>;
-  auto surface = make22313<R2>();
-
-  GIVEN("The Quadrilateral " << *surface) {
-    // We check that this saddle connection from -3 to 6 is found; verifying
-    // that a bug that appeared in early 2021 has been fixed.
-    const auto search = Vector<T>(-L_->gen() + 2, 0);
-    // The connections starting at edge -3 of length at most sqrt(7)
-    const auto connections = SaddleConnections<FlatTriangulation<T>>(*surface).sector(-3).bound(Bound::upper(search));
-    REQUIRE(std::find_if(begin(connections), end(connections), [&](const auto& connection) {
-      return connection.vector() == search;
-    }) != end(connections));
-  }
-}
-
 TEMPLATE_TEST_CASE("Saddle Connections on a Torus", "[saddle_connections]", (long long), (mpq_class), (renf_elem_class), (exactreal::Element<exactreal::IntegerRing>), (exactreal::Element<exactreal::NumberField>)) {
   using R2 = Vector<TestType>;
   auto square = makeSquare<R2>();
@@ -200,7 +183,7 @@ TEMPLATE_TEST_CASE("Saddle Connections on a Surface", "[saddle_connections]", (l
       const auto connection = GENERATE_REF(saddleConnections(surface, 3));
       const auto bound = Bound::upper(connection.vector());
 
-      AND_GIVEN("The saddle connection " << connection) {
+      GIVEN("The saddle connection " << connection) {
         THEN("There is exactly that saddle connection in the sector bounded by this connection") {
           const auto connections_ = surface->connections().bound(2 * bound).sector(connection, connection);
           REQUIRE(std::distance(begin(connections_), end(connections_)) == 1);
@@ -215,9 +198,16 @@ TEMPLATE_TEST_CASE("Saddle Connections on a Surface", "[saddle_connections]", (l
           const auto connections_ = surface->connections().bound(2 * bound).sector(connection.vector(), connection.vector()).sector(connection.source());
           REQUIRE(std::distance(begin(connections_), end(connections_)) == 1);
         }
+
+        THEN("There is that saddle connection among the connections starting at its source and using its length as a bound") {
+          const auto connections = surface->connections().bound(Bound::upper(connection.vector())).sector(connection.source());
+          REQUIRE(std::find_if(begin(connections), end(connections), [&](const auto& c) {
+            return c == connection;
+          }) != end(connections));
+        }
       }
 
-      AND_GIVEN("Two connections that define sectors that cover the entire plane") {
+      GIVEN("Two connections that define sectors that cover the entire plane") {
         const auto sectorBegin = connection;
         const auto sectorEnd = GENERATE_REF(saddleConnections(surface, 3));
 

--- a/libflatsurf/test/surfaces.hpp
+++ b/libflatsurf/test/surfaces.hpp
@@ -44,6 +44,7 @@ using std::vector;
 namespace flatsurf::test {
 static auto K = renf_class::make("x^2 - 3", "x", "1.73 +/- .1");
 static auto L = renf_class::make("x^2 - x - 1", "x", "1.618 +/- .1");
+static auto L_ = renf_class::make("x^2 - x - 1", "x", "-.618 +/- .1");
 static auto M = renf_class::make("x^3 - x^2 - 2*x +1", "x", "1.802 +/- .1");
 static auto N = renf_class::make("x^2 - 2", "x", "1.414 +/- .1");
 static auto O = renf_class::make("x^4 - 2", "x", "1.189 +/- .1");
@@ -286,6 +287,19 @@ auto make1234() {
   const auto frac = ::flatsurf::test::frac<renf_elem_class, int>;
   vectors = vector{R2(frac(1, 2) * a * a + 4, -frac(1, 2) * a * a * a + frac(3, 2) * a), R2(-a * a - 2, 0), R2(frac(1, 2) * a * a - 2, frac(1, 2) * a * a * a - frac(3, 2) * a), R2(frac(1, 2) * a * a + 4, frac(1, 2) * a * a * a - frac(3, 2) * a), R2(-frac(1, 2) * a * a + 1, -frac(1, 2) * a * a * a + frac(3, 2) * a), R2(-5, 0), R2(3 * a * a - frac(17, 2), -frac(1, 2) * a * a * a - 1 * a), R2(-frac(1, 2) * a * a + 1, frac(1, 2) * a * a * a - frac(3, 2) * a), R2(-frac(5, 2) * a * a + frac(15, 2), frac(5, 2) * a), R2(-3 * a * a + frac(13, 2), -frac(5, 2) * a * a * a + 7 * a), R2(frac(1, 2) * a * a - frac(3, 2), frac(1, 2) * a), R2(frac(5, 2) * a * a - 5, frac(5, 2) * a * a * a - frac(15, 2) * a), R2(-3 * a * a + frac(13, 2), frac(5, 2) * a * a * a - 7 * a), R2(frac(5, 2) * a * a - frac(9, 2), -2 * a * a * a + frac(11, 2) * a), R2(frac(1, 2) * a * a - 2, -frac(1, 2) * a * a * a + frac(3, 2) * a), R2(3 * a * a - frac(17, 2), frac(1, 2) * a * a * a + 1 * a), R2(-2 * a * a + frac(11, 2), -frac(1, 2) * a * a * a - 1 * a), R2(-a * a + 3, 0), R2(2 * a * a - 6, -3 * a), R2(-2 * a * a + frac(11, 2), frac(1, 2) * a * a * a + 1 * a), R2(frac(1, 2), -frac(1, 2) * a * a * a + 2 * a), R2(-frac(5, 2) * a * a + 4, -frac(5, 2) * a * a * a + frac(15, 2) * a), R2(frac(5, 2) * a * a - frac(9, 2), 2 * a * a * a - frac(11, 2) * a), R2(frac(1, 2), frac(1, 2) * a * a * a - 2 * a), R2(-frac(5, 2) * a * a + 4, frac(5, 2) * a * a * a - frac(15, 2) * a), R2(1, 0), R2(frac(5, 2) * a * a - 5, -frac(5, 2) * a * a * a + frac(15, 2) * a), R2(2 * a * a - 6, 3 * a), R2(frac(1, 2) * a * a - frac(3, 2), -frac(1, 2) * a), R2(-frac(5, 2) * a * a + frac(15, 2), -frac(5, 2) * a)};
   return std::make_shared<FlatTriangulation<typename R2::Coordinate>>(std::move(*make1234Combinatorial()), vectors);
+}
+
+inline auto make22313Combinatorial() {
+  auto vertices = vector<vector<int>>{{1, -3, -5, 20, 19, -18, 45, 44, 40, 6}, {-1, -7, -23, -37, 39, -38, 46, 32, 4, 3, -2, -9, -25, 30, 10, -12, -14, 28, 27, -26, 14, -13, 5, -4, -33, -42, 38, 34, 21, -20, 13, 12, -11, -16, -24, 25, 17, -19, -21, -35, -41, 37, -36, -48, 18, -17, 9, -8, 16, -15, -27, -29, -45, 48, 47, -46, 42, -43, -44, 29, -28, 26, 15, 11, -10, -31, -40, 43, 33, -32, -47, 36, 23, -22, 35, -34, -39, 41, 22, 7, -6, 31, -30, 24, 8, 2}};
+  return std::make_shared<FlatTriangulationCombinatorial>(vertices);
+}
+
+template <typename R2>
+auto make22313() {
+  vector<R2> vectors;
+  auto a = L_->gen();
+  vectors = vector{ R2(0, -1),  R2(1, 0),  R2(-1, 1),  R2(a - 1, -a + 2), R2(-a, a - 1), R2(-1, -a + 1), R2(1, a - 2), R2(0, a), R2(1, -a), R2(-2 * a + 1, 3 * a - 4), R2(a + 1, 0), R2(a - 2, -3 * a + 4), R2(0, -a + 1), R2(a - 2, -2 * a + 3), R2(1, a - 1), R2(a, -a + 1), R2(-1, -a + 2), R2(0, -1), R2(1, a - 1), R2(a, 0), R2(-a + 1, a - 1), R2(a - 2, -a + 2), R2(-a + 3, 2 * a - 4), R2(a, 1), R2(0, -2 * a + 2), R2(a + 1, -1), R2(-a, a), R2(-2 * a + 1, 2 * a - 2), R2(a - 1, -a + 2), R2(-a, 2 * a - 3), R2(-a + 1, a - 1), R2(-2, -2 * a + 4), R2(a + 1, a - 2), R2(-a-1, 0), R2(2, a - 1), R2(-a + 3, 3 * a - 4), R2(0, -a), R2(-1, -a + 1), R2(-a, a - 1), R2(-a, 0), R2(a, 1), R2(a + 1, -1), R2(0, a - 1), R2(-a, a - 1), R2(-1, 1), R2(-a, a), R2(a - 2, -3 * a + 4), R2(1, 0)};
+  return std::make_shared<FlatTriangulation<typename R2::Coordinate>>(std::move(*make22313Combinatorial()), vectors);
 }
 
 }  // namespace flatsurf::test

--- a/pyflatsurf/recipe/meta.yaml
+++ b/pyflatsurf/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - libflatsurf
   run:
     - python
-    - cppyy
+    - cppyy >=1.9.3
     - cppyythonizations
     - pyexactreal >=1.3.2
     - boost-cpp


### PR DESCRIPTION
Do not abort saddle connection search when the endpoints of "next edge" are outside the search radius but only when the entire edge is outside. Before, the purple connection was not found in the green sector when using the red bound.

![image](https://user-images.githubusercontent.com/373765/108252250-bacd2780-7158-11eb-8803-4f5b506ed217.png)

This was originally meant as a speedup as we did not care much about the bounds.