### PR TITLE
Add SaddleConnection::path()

### DIFF
--- a/doc/news/intersection.rst
+++ b/doc/news/intersection.rst
@@ -1,0 +1,10 @@
+**Added:**
+
+* Added `SaddleConnection::path()` that returns a more detailed path of a
+  saddle connection than did `SaddleConnection::crossings()`. This can be used
+  to properly shade components of a flow decomposition when drawing them.
+
+**Deprecated:**
+
+* The method `SaddleConnection::crossings()` has been superseded by
+  `SaddleConnection::path()`.

--- a/libflatsurf/flatsurf/forward.hpp
+++ b/libflatsurf/flatsurf/forward.hpp
@@ -48,6 +48,9 @@ template <typename Surface>
 class ContourDecomposition;
 
 template <typename Surface>
+class HalfEdgeIntersection;
+
+template <typename Surface>
 class DecompositionStep;
 
 template <typename Surface>

--- a/libflatsurf/flatsurf/half_edge_intersection.hpp
+++ b/libflatsurf/flatsurf/half_edge_intersection.hpp
@@ -1,0 +1,64 @@
+/**********************************************************************
+ *  This file is part of flatsurf.
+ *
+ *        Copyright (C) 2021 Julian Rüth
+ *
+ *  Flatsurf is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Flatsurf is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with flatsurf. If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************/
+
+#ifndef LIBFLATSURF_HALF_EDGE_INTERSECTION_HPP
+#define LIBFLATSURF_HALF_EDGE_INTERSECTION_HPP
+
+#include <boost/operators.hpp>
+#include <optional>
+
+#include "copyable.hpp"
+
+namespace flatsurf {
+
+/// The intersection of a saddle connection and a half edge.
+template <typename Surface>
+class HalfEdgeIntersection : boost::less_than_comparable<HalfEdgeIntersection<Surface>> {
+  static_assert(std::is_same_v<Surface, std::decay_t<Surface>>, "type must not have modifiers such as const");
+
+  using T = typename Surface::Coordinate;
+
+  template <typename... Args>
+  HalfEdgeIntersection(PrivateConstructor, Args &&... args);
+
+ public:
+  // Return the approximate point where this crosses the half edge as a number
+  // in `[0, 1]`, correct to double precision.
+  double at() const;
+
+  // Return the half edge this crosses.
+  HalfEdge halfEdge() const;
+
+  template <typename S>
+  friend std::ostream& operator<<(std::ostream&, const HalfEdgeIntersection<S>&);
+
+  // Return whether this intersection crosses a half edge closer to its start
+  // than `rhs`.
+  // This operator is consistent with `at`, i.e., if `a.at() < b.at()`, then `a < b`.
+  bool operator<(const HalfEdgeIntersection& rhs) const;
+
+ private:
+  Copyable<HalfEdgeIntersection> self;
+
+  friend ImplementationOf<HalfEdgeIntersection>;
+};
+
+}
+
+#endif

--- a/libflatsurf/flatsurf/saddle_connection.hpp
+++ b/libflatsurf/flatsurf/saddle_connection.hpp
@@ -1,7 +1,7 @@
 /**********************************************************************
  *  This file is part of flatsurf.
  *
- *        Copyright (C) 2019-2020 Julian Rüth
+ *        Copyright (C) 2019-2021 Julian Rüth
  *
  *  Flatsurf is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -71,13 +71,19 @@ class SaddleConnection : public Serializable<SaddleConnection<Surface>>,
   // It is leaving in a direction that is contained in the sector next to
   // source (counterclockwise) inclusive.
   HalfEdge source() const;
+
   // Symmetrical to source(), the connection is such that -vector() is in the
   // sector counterclockwise next to target() inclusive.
   HalfEdge target() const;
 
   const Surface &surface() const;
 
+  // Return the sequence of half edges this saddle connection crosses.
+  [[deprecated("Use path() instead")]]
   std::vector<HalfEdge> crossings() const;
+
+  // The sequence of vertices and half edges this saddle connection crosses.
+  std::vector<HalfEdgeIntersection<Surface>> path() const;
 
   std::optional<int> angle(const SaddleConnection<Surface> &) const;
 

--- a/libflatsurf/flatsurf/saddle_connections_iterator.hpp
+++ b/libflatsurf/flatsurf/saddle_connections_iterator.hpp
@@ -1,7 +1,7 @@
 /**********************************************************************
  *  This file is part of flatsurf.
  *
- *        Copyright (C) 2020 Julian Rüth
+ *        Copyright (C) 2020-2021 Julian Rüth
  *
  *  Flatsurf is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -40,12 +40,27 @@ class SaddleConnectionsIterator : public boost::iterator_facade<SaddleConnection
  public:
   // Advance the iterator to the next saddle connection.
   void increment();
+
   // Advance the iterator to the next saddle connection or until a HalfEdge is
   // being crossed during the search (in forward direction.) This can be useful
   // if information about the exact path in the surface for a saddle connection
   // needs to be reconstructed.
+  [[deprecated("Use incrementWithIntersections() instead.")]]
   std::optional<HalfEdge> incrementWithCrossings();
+
+  // Advance the iterator to the next saddle connection or until a HalfEdge is
+  // being crossed during the search (in forward direction.) This can be useful
+  // if information about the exact path in the surface for a saddle connection
+  // needs to be reconstructed.
+  // Note that the iterator is initially starting on a saddle connection. The
+  // intersections reported by this method do not include the ones that were
+  // taken to get to that initial saddle connection, i.e., setting a
+  // lower/upper bound or a sector that excludes the source half edge, will
+  // lead to missing initial intersections.
+  std::optional<std::pair<Chain<Surface>, HalfEdge>> incrementWithIntersections();
+
   bool equal(const SaddleConnectionsIterator &other) const;
+
   const SaddleConnection<Surface> &dereference() const;
 
   void skipSector(CCW sector);

--- a/libflatsurf/src/Makefile.am
+++ b/libflatsurf/src/Makefile.am
@@ -31,6 +31,7 @@ libflatsurf_la_SOURCES =                                            \
 	flow_decomposition_state.cc                                 \
 	flow_triangulation.cc                                       \
 	half_edge.cc                                                \
+	half_edge_intersection.cc                                   \
 	indexed_set.cc                                              \
 	indexed_set_iterator.cc                                     \
 	interval_exchange_transformation.cc                         \
@@ -89,6 +90,7 @@ nobase_pkginclude_HEADERS =                                         \
 	../flatsurf/fmt.hpp                                         \
 	../flatsurf/forward.hpp                                     \
 	../flatsurf/half_edge.hpp                                   \
+	../flatsurf/half_edge_intersection.hpp                      \
 	../flatsurf/half_edge_map.hpp                               \
 	../flatsurf/half_edge_set.hpp                               \
 	../flatsurf/half_edge_set_iterator.hpp                      \
@@ -145,6 +147,7 @@ noinst_HEADERS =                                                    \
 	impl/flow_decomposition_state.hpp                           \
 	impl/flow_triangulation.impl.hpp                            \
 	impl/forward.hpp                                            \
+	impl/half_edge_intersection.impl.hpp                        \
 	impl/half_edge_set.impl.hpp                                 \
 	impl/half_edge_set_iterator.impl.hpp                        \
 	impl/indexed_map.hpp                                        \

--- a/libflatsurf/src/half_edge_intersection.cc
+++ b/libflatsurf/src/half_edge_intersection.cc
@@ -1,0 +1,111 @@
+/**********************************************************************
+ *  This file is part of flatsurf.
+ *
+ *        Copyright (C) 2021 Julian Rüth
+ *
+ *  Flatsurf is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Flatsurf is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with flatsurf. If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************/
+
+#include <exact-real/yap/arb.hpp>
+
+#include "../flatsurf/half_edge.hpp"
+#include "../flatsurf/half_edge_intersection.hpp"
+#include "../flatsurf/vector.hpp"
+
+#include "impl/half_edge_intersection.impl.hpp"
+#include "impl/approximation.hpp"
+#include "util/assert.ipp"
+
+#include <ostream>
+
+namespace flatsurf {
+
+template <typename Surface>
+HalfEdge HalfEdgeIntersection<Surface>::halfEdge() const {
+  return self->halfEdge;
+}
+
+template <typename Surface>
+bool HalfEdgeIntersection<Surface>::operator<(const HalfEdgeIntersection& rhs) const {
+  const auto relative = self->relative();
+  const auto relative_ = rhs.self->relative();
+
+  return std::get<0>(relative) * std::get<1>(relative_) < std::get<0>(relative_) * std::get<1>(relative);
+}
+
+template <typename Surface>
+double HalfEdgeIntersection<Surface>::at() const {
+  const auto relative = self->relative();
+
+  for (long prec = 64;; prec *= 2) {
+    const exactreal::Arb quotient = (Approximation<T>::arb(std::get<0>(relative), prec) / Approximation<T>::arb(std::get<1>(relative), prec))(prec);
+
+    auto bounds = static_cast<std::pair<exactreal::Arf, exactreal::Arf>>(quotient);
+    auto lower = static_cast<double>(bounds.first);
+    auto upper = static_cast<double>(bounds.second);
+
+    if (upper == lower)
+      return upper;
+  }
+}
+
+template <typename Surface>
+std::tuple<typename Surface::Coordinate, typename Surface::Coordinate, typename Surface::Coordinate> ImplementationOf<HalfEdgeIntersection<Surface>>::projective() const {
+  // The two lines in projective space.
+  const std::tuple<T, T, T> line{-direction.y(), direction.x(), direction.y() * base.x() - direction.x() * base.y()};
+  const std::tuple<T, T, T> line_{-surface->fromHalfEdge(halfEdge).y(), surface->fromHalfEdge(halfEdge).x(), T{}};
+
+  return std::tuple{
+    std::get<2>(line_) * std::get<1>(line) - std::get<2>(line) * std::get<1>(line_),
+    std::get<2>(line) * std::get<0>(line_) - std::get<2>(line_) * std::get<0>(line),
+    std::get<1>(line_) * std::get<0>(line) - std::get<0>(line_) * std::get<1>(line),
+  };
+}
+
+template <typename Surface>
+std::tuple<typename Surface::Coordinate, typename Surface::Coordinate> ImplementationOf<HalfEdgeIntersection<Surface>>::relative() const {
+  const auto projective = this->projective();
+  LIBFLATSURF_ASSERT(std::get<2>(projective), "HalfEdge and SaddleConnection must intersect at a finite point.");
+
+  LIBFLATSURF_ASSERT(std::get<0>(projective) || std::get<1>(projective), "HalfEdge and SaddleConnection must not intersect at the end point of the half edge but " << base << " + λ·" << direction << " intersects " << halfEdge << " in its origin.");
+
+  LIBFLATSURF_ASSERT((std::get<0>(projective) == 0) == (surface->fromHalfEdge(halfEdge).x() == 0), "Intersection point must be on the half edge.");
+  LIBFLATSURF_ASSERT((std::get<1>(projective) == 0) == (surface->fromHalfEdge(halfEdge).y() == 0), "Intersection point must be on the half edge.");
+
+  if (std::get<0>(projective))
+    return {std::get<0>(projective), std::get<2>(projective) * surface->fromHalfEdge(halfEdge).x()};
+  else
+    return {std::get<1>(projective), std::get<2>(projective) * surface->fromHalfEdge(halfEdge).y()};
+}
+
+template <typename Surface>
+ImplementationOf<HalfEdgeIntersection<Surface>>::ImplementationOf(const Surface& surface, const Vector<T>& base, HalfEdge halfEdge, const Vector<T>& direction) : surface(surface), base(base), direction(direction), halfEdge(halfEdge) {}
+
+template <typename Surface>
+HalfEdgeIntersection<Surface> ImplementationOf<HalfEdgeIntersection<Surface>>::make(const Surface& surface, const Vector<T>& base, HalfEdge cross, const Vector<T>& direction) {
+  return HalfEdgeIntersection<Surface>(PrivateConstructor{}, surface, base, cross, direction);
+}
+
+template <typename Surface>
+std::ostream& operator<<(std::ostream& os, const HalfEdgeIntersection<Surface>& self) {
+  return os << self.at() << " * " << self.halfEdge();
+}
+
+}
+
+// Instantiations of templates so implementations are generated for the linker
+#include "util/instantiate.ipp"
+
+LIBFLATSURF_INSTANTIATE_MANY_WRAPPED((LIBFLATSURF_INSTANTIATE_WITH_IMPLEMENTATION), HalfEdgeIntersection, LIBFLATSURF_FLAT_TRIANGULATION_TYPES)
+

--- a/libflatsurf/src/impl/half_edge_intersection.impl.hpp
+++ b/libflatsurf/src/impl/half_edge_intersection.impl.hpp
@@ -1,0 +1,63 @@
+/**********************************************************************
+ *  This file is part of flatsurf.
+ *
+ *        Copyright (C) 2021 Julian Rüth
+ *
+ *  Flatsurf is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Flatsurf is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with flatsurf. If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************/
+
+#ifndef LIBFLATSURF_HALF_EDGE_INTERSECTION_IMPL_HPP
+#define LIBFLATSURF_HALF_EDGE_INTERSECTION_IMPL_HPP
+
+#include "../../flatsurf/half_edge_intersection.hpp"
+
+#include "../../flatsurf/half_edge.hpp"
+#include "../../flatsurf/vector.hpp"
+#include "read_only.hpp"
+
+namespace flatsurf {
+
+template <typename Surface>
+class ImplementationOf<HalfEdgeIntersection<Surface>> {
+  using T = typename Surface::Coordinate;
+
+ public:
+  ImplementationOf(const Surface&, const Vector<T>& base, HalfEdge halfEdge, const Vector<T>& direction);
+
+  // Return the intersection corresponding to the saddle connection with
+  // `direction` as it is crossing over `cross`. The half edge is assumed to be
+  // anchored in the coordinate origin and the saddle connection to start at
+  // `base`.
+  static HalfEdgeIntersection<Surface> make(const Surface&, const Vector<T>& base, HalfEdge cross, const Vector<T>& direction);
+
+  // Return the projective coordinates of the intersection point.
+  std::tuple<T, T, T> projective() const;
+
+  // Return the coordinate of the intersection point on the half edge as a fraction in [0, 1].
+  std::tuple<T, T> relative() const;
+
+  ReadOnly<Surface> surface;
+  Vector<T> base;
+  Vector<T> direction;
+  HalfEdge halfEdge;
+};
+
+template <typename Surface>
+template <typename... Args>
+HalfEdgeIntersection<Surface>::HalfEdgeIntersection(PrivateConstructor, Args&&... args) :
+  self(spimpl::make_impl<ImplementationOf<HalfEdgeIntersection>>(std::forward<Args>(args)...)) {}
+
+}
+
+#endif


### PR DESCRIPTION
to properly shade flow components in ipyvue-flatsurf.

fixes #153.