### PR TITLE
Fix eliminate_marked_points in trivial cases

### DIFF
--- a/doc/news/rectangle.rst
+++ b/doc/news/rectangle.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fix tracking of collapsed half edges in `FlatTriangulation::operator+()`.

--- a/libflatsurf/src/flat_triangulation.cc
+++ b/libflatsurf/src/flat_triangulation.cc
@@ -276,7 +276,7 @@ Deformation<FlatTriangulation<T>> FlatTriangulation<T>::operator+(const OddHalfE
     // Maps half edges to their vectors in the resulting surface.
     Tracked<OddHalfEdgeMap<Vector<T>>> vectors(combinatorial, OddHalfEdgeMap<Vector<T>>(combinatorial, [&](const HalfEdge he) { return fromHalfEdge(he) + shift.get(he); }),
       Tracked<OddHalfEdgeMap<Vector<T>>>::defaultFlip,
-      [&](auto &vectors, const FlatTriangulationCombinatorial &surface, Edge e) {
+      [&](auto &vectors, const FlatTriangulationCombinatorial &, Edge e) {
         LIBFLATSURF_ASSERT(!vectors.get(e.positive()), "can only collapse half edges that have become trivial");
       });
 

--- a/libflatsurf/src/flat_triangulation.cc
+++ b/libflatsurf/src/flat_triangulation.cc
@@ -242,65 +242,72 @@ Deformation<FlatTriangulation<T>> FlatTriangulation<T>::operator+(const OddHalfE
   } else {
     // We don't need to flip, so we perform shifts of half edges on a copy of
     // the surface's vector structure and collapse on a copy of the
-    // combinatorial structure.
+    // combinatorial structure if necessary.
     auto combinatorial = static_cast<const FlatTriangulationCombinatorial &>(*this).clone();
 
     // When trivial half edges are collapsed, the other edges in a triangle
-    // are identified. We keep track of such identifications here, mapping a
-    // half edge to all its preimages under this identification.
-    Tracked<HalfEdgeMap<std::unordered_set<HalfEdge>>> halfEdges(combinatorial, HalfEdgeMap<std::unordered_set<HalfEdge>>(combinatorial, [](const HalfEdge he) { return std::unordered_set{he}; }),
-        Tracked<HalfEdgeMap<std::unordered_set<HalfEdge>>>::defaultFlip,
-        [](HalfEdgeMap<std::unordered_set<HalfEdge>> &self, const FlatTriangulationCombinatorial &surface, Edge e) {
-          const auto copy = [&](const HalfEdge from, const HalfEdge to) {
-            for (const auto he : self[from])
-              self[to].insert(he);
-          };
+    // are identified. We keep track of such identifications here, keeping all
+    // identified half edges in a set.
+    HalfEdgeMap<HalfEdge> identified{combinatorial, [](HalfEdge he) { return he; }};
 
-          const auto equate = [&](const HalfEdge a, const HalfEdge b) {
-            copy(a, b);
-            copy(b, a);
-          };
+    const std::function<HalfEdge(HalfEdge)> find_ = [&](HalfEdge a) {
+      if (identified[a] == a)
+        return a;
+      return identified[a] = find_(identified[a]);
+    };
 
-          for (const auto collapse : {e.positive(), e.negative()}) {
-            equate(surface.nextInFace(collapse), -surface.previousInFace(collapse));
-            equate(-surface.nextInFace(collapse), surface.previousInFace(collapse));
-          }
-        });
+    const auto union_ = [&](HalfEdge a, HalfEdge b) {
+      LIBFLATSURF_ASSERT(fromHalfEdge(a) + shift.get(a) == fromHalfEdge(b) + shift.get(b), "A shift identified " << a << " and " << b << " but the shift was supposed to send " << a << " from " << fromHalfEdge(a) << " to " << fromHalfEdge(a) + shift.get(a) << " and " << b << " from " << fromHalfEdge(b) << " to " << fromHalfEdge(b) + shift.get(b) << " which is not the same.");
 
+      identified[find_(a)] = b;
+    };
+
+    // Maps each half edge to one of its preimages in the surface before collapsing.
+    Tracked<HalfEdgeMap<HalfEdge>> preimage(combinatorial, HalfEdgeMap<HalfEdge>(combinatorial, [](HalfEdge he) { return he; }),
+      Tracked<HalfEdgeMap<HalfEdge>>::defaultFlip,
+      [&](auto &self, const FlatTriangulationCombinatorial &surface, Edge e) {
+
+        for (const auto he : {e.positive(), e.negative()}) {
+          union_(self[surface.nextInFace(he)], self[-surface.previousInFace(he)]);
+          union_(self[-surface.nextInFace(he)], self[surface.previousInFace(he)]);
+        }
+      });
+
+    // Maps half edges to their vectors in the resulting surface.
     Tracked<OddHalfEdgeMap<Vector<T>>> vectors(combinatorial, OddHalfEdgeMap<Vector<T>>(combinatorial, [&](const HalfEdge he) { return fromHalfEdge(he) + shift.get(he); }),
-        Tracked<OddHalfEdgeMap<Vector<T>>>::defaultFlip,
-        [](OddHalfEdgeMap<Vector<T>> &vectors, const FlatTriangulationCombinatorial &, Edge e) {
-          LIBFLATSURF_ASSERT(!vectors.get(e.positive()), "can only collapse half edges that have become trivial");
-        });
+      Tracked<OddHalfEdgeMap<Vector<T>>>::defaultFlip,
+      [&](auto &vectors, const FlatTriangulationCombinatorial &surface, Edge e) {
+        LIBFLATSURF_ASSERT(!vectors.get(e.positive()), "can only collapse half edges that have become trivial");
+      });
 
+    // The edges that need to be collapsed in the target surface.
     Tracked<EdgeSet> collapsing_(combinatorial, collapsing,
-        Tracked<EdgeSet>::defaultFlip,
-        [](EdgeSet &self, const FlatTriangulationCombinatorial &, Edge e) {
-          LIBFLATSURF_ASSERT(self.contains(e), "can only collapse edges that have been found to collapse at t=1");
-        });
+      Tracked<EdgeSet>::defaultFlip,
+      [](auto &self, const FlatTriangulationCombinatorial &, Edge e) {
+        LIBFLATSURF_ASSERT(self.contains(e), "can only collapse edges that have been found to collapse at t=1");
+      });
 
+    // Collapse edges in the combinatorial structure.
     while (!collapsing_->empty())
       combinatorial.collapse(begin(static_cast<const EdgeSet &>(collapsing_))->positive());
 
     const auto codomain = FlatTriangulation<T>(
-        std::move(combinatorial),
-        [&](const HalfEdge he) { return vectors->get(he); });
+      std::move(combinatorial),
+      [&](const HalfEdge he) { return vectors->get(he); });
 
     return ImplementationOf<Deformation<FlatTriangulation>>::make(std::make_unique<ShiftDeformationRelation<FlatTriangulation>>(
-        *this,
-        codomain,
-        OddHalfEdgeMap<Path<FlatTriangulation>>(*this, [&](HalfEdge he) {
-          for (const auto &image : codomain.halfEdges()) {
-            for (const auto &preimage : halfEdges->operator[](image)) {
-              if (preimage == he) {
-                LIBFLATSURF_ASSERT(vectors->get(image) == fromHalfEdge(he) + shift.get(he), "Half edge " << he << " should have been shifted from " << fromHalfEdge(he) << " to " << fromHalfEdge(he) + shift.get(he) << " but instead it became " << image << " which is " << vectors->get(image));
-                return Path{SaddleConnection<FlatTriangulation>(codomain, image)};
-              }
-            }
+      *this,
+      codomain,
+      OddHalfEdgeMap<Path<FlatTriangulation>>(*this, [&](HalfEdge he) {
+        for (const HalfEdge image : codomain.halfEdges()) {
+          if (find_((*preimage)[image]) == find_(he)) {
+            LIBFLATSURF_ASSERT(vectors->get(image) == fromHalfEdge(he) + shift.get(he), "Half edge " << he << " should have been shifted from " << fromHalfEdge(he) << " to " << fromHalfEdge(he) + shift.get(he) << " but instead it became " << image << " which is " << vectors->get(image));
+            return Path{SaddleConnection<FlatTriangulation>(codomain, image)};
           }
-          // This half edge has been collapsed.
-          return Path<FlatTriangulation>{};
-        })));
+        }
+        // This half edge has been collapsed.
+        return Path<FlatTriangulation>{};
+      })));
   }
 }
 
@@ -398,7 +405,7 @@ Deformation<FlatTriangulation<T>> FlatTriangulation<T>::eliminateMarkedPoints() 
     return elimination;
   }
 
-  LIBFLATSURF_UNREACHABLE("No half edge was sent to a single saddle conection in deformation " << shift);
+  LIBFLATSURF_UNREACHABLE("No half edge was sent to a single saddle conection in deformation " << shift << " which eliminated " << marked << " by applying " << delta);
 }
 
 template <typename T>

--- a/libflatsurf/src/flat_triangulation.cc
+++ b/libflatsurf/src/flat_triangulation.cc
@@ -101,15 +101,17 @@ Deformation<FlatTriangulation<T>> FlatTriangulation<T>::operator+(const OddHalfE
     for (size_t i = 0; i < outgoing.size(); i++) {
       const auto he = outgoing.at(i);
 
-      if (fromHalfEdge(he).ccw(shift.get(he)) == CCW::COLLINEAR) {
-        switch (fromHalfEdge(he).orientation(fromHalfEdge(he) + shift.get(he))) {
-          case ORIENTATION::SAME:
-            // The critical time t is not in [0, 1]
-            break;
-          case ORIENTATION::OPPOSITE:
-            throw std::invalid_argument("shift must not collapse half edges for a time t in (0, 1)");
-          case ORIENTATION::ORTHOGONAL:
-            collapsing.insert(he);
+      if (shift.get(he)) {
+        if (fromHalfEdge(he).ccw(shift.get(he)) == CCW::COLLINEAR) {
+          switch (fromHalfEdge(he).orientation(fromHalfEdge(he) + shift.get(he))) {
+            case ORIENTATION::SAME:
+              // The critical time t is not in [0, 1]
+              break;
+            case ORIENTATION::OPPOSITE:
+              throw std::invalid_argument("shift must not collapse half edges for a time t in (0, 1)");
+            case ORIENTATION::ORTHOGONAL:
+              collapsing.insert(he);
+          }
         }
       }
     }

--- a/libflatsurf/src/tracked.cc
+++ b/libflatsurf/src/tracked.cc
@@ -1,7 +1,7 @@
 /**********************************************************************
  *  This file is part of flatsurf.
  *
- *        Copyright (C) 2020 Julian Rüth
+ *        Copyright (C) 2020-2021 Julian Rüth
  *
  *  Flatsurf is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -288,8 +288,6 @@ void ImplementationOf<Tracked<T>>::connect() {
 }  // namespace flatsurf
 
 // Instantiations of templates so implementations are generated for the linker
-#include <unordered_set>
-
 #include "../flatsurf/ccw.hpp"
 #include "../flatsurf/edge_map.hpp"
 #include "../flatsurf/edge_set.hpp"
@@ -306,7 +304,7 @@ LIBFLATSURF_INSTANTIATE((LIBFLATSURF_INSTANTIATE_WITH_IMPLEMENTATION), (Tracked<
 LIBFLATSURF_INSTANTIATE((LIBFLATSURF_INSTANTIATE_WITH_IMPLEMENTATION), (Tracked<HalfEdgeSet>))
 LIBFLATSURF_INSTANTIATE((LIBFLATSURF_INSTANTIATE_WITH_IMPLEMENTATION), (Tracked<EdgeSet>))
 LIBFLATSURF_INSTANTIATE((LIBFLATSURF_INSTANTIATE_WITH_IMPLEMENTATION), (Tracked<OddHalfEdgeMap<HalfEdge>>))
-LIBFLATSURF_INSTANTIATE((LIBFLATSURF_INSTANTIATE_WITH_IMPLEMENTATION), (Tracked<HalfEdgeMap<std::unordered_set<HalfEdge>>>))
+LIBFLATSURF_INSTANTIATE((LIBFLATSURF_INSTANTIATE_WITH_IMPLEMENTATION), (Tracked<HalfEdgeMap<HalfEdge>>))
 
 #define LIBFLATSURF_WRAP_ODD_HALF_EDGE_MAP_VECTOR(R, TYPE, T) (TYPE<OddHalfEdgeMap<Vector<T>>>)
 LIBFLATSURF_INSTANTIATE_MANY_FROM_TRANSFORMATION((LIBFLATSURF_INSTANTIATE_WITH_IMPLEMENTATION), Tracked, LIBFLATSURF_REAL_TYPES(exactreal::Arb), LIBFLATSURF_WRAP_ODD_HALF_EDGE_MAP_VECTOR)

--- a/libflatsurf/test/generators/surface_generator.hpp
+++ b/libflatsurf/test/generators/surface_generator.hpp
@@ -37,6 +37,7 @@ template <typename T>
 class SurfaceGenerator : public Catch::Generators::IGenerator<std::tuple<std::string*, std::shared_ptr<FlatTriangulation<T>>*>> {
   enum class Surface {
     SQUARE,
+    RECTANGLE,
     L,
     MCMULLEN_L1114,
     MCMULLEN_L2111,
@@ -72,6 +73,10 @@ class SurfaceGenerator : public Catch::Generators::IGenerator<std::tuple<std::st
       case Surface::SQUARE:
         name = "Torus";
         value = makeSquare<R2>();
+        return;
+      case Surface::RECTANGLE:
+        name = "Rectangle";
+        value = makeRectangle<R2>();
         return;
       case Surface::L:
         name = "L";

--- a/libflatsurf/test/surfaces.hpp
+++ b/libflatsurf/test/surfaces.hpp
@@ -67,6 +67,17 @@ inline auto makeSquareWithBoundaryCombinatorial() {
   return std::make_shared<FlatTriangulationCombinatorial>(vertices, std::vector{2, -4});
 }
 
+inline auto makeRectangleCombinatorial() {
+  auto vertices = vector<vector<int>>{{1, -3, 7, -9, 10, -12, 4, -6}, {-1, 8, -7, 11, -10, 5, -4, 2}, {-2, 12, -11, 3}, {-5, 9, -8, 6}};
+  return std::make_shared<FlatTriangulationCombinatorial>(vertices);
+}
+
+template <typename R2>
+auto makeRectangle() {
+  auto vectors = vector{R2{1, 6}, R2{-1, 0}, R2{0, -6}, R2{1, -6}, R2{0, 6}, R2{-1, 0}, R2{-1, 6}, R2{0, -6}, R2{1, 0}, R2{-1, -6}, R2{1, 0}, R2{0, 6}};
+  return std::make_shared<FlatTriangulation<typename R2::Coordinate>>(std::move(*makeRectangleCombinatorial()), vectors);
+}
+
 template <typename R2>
 auto makeSquareWithBoundary() {
   auto vectors = vector{R2(1, 0), R2(0, 1), R2(1, 1), R2(0, 1)};


### PR DESCRIPTION
Fixes:
```
LIBFLATSURF_ASSERT_CONDITION(!image->empty()) does not hold: Edge 1 has not
been collapsed so it should be non-trivial in the image. in ../../../
flatsurf/libflatsurf/src/flat_triangulation.cc:370
```