### PR TITLE
Allow Tracked<Deformation> to follow flips in a surface

### DIFF
--- a/doc/news/delaunay-tracked.rst
+++ b/doc/news/delaunay-tracked.rst
@@ -4,3 +4,4 @@
   a move assignment operator for a `Deformation`.
 * Implemented special handling of a `Tracked<Deformation>` so that it can track
   flips in the tracked triangulation.
+* Added glue to `flatsurf::Tracked` to pyflatsurf.

--- a/doc/news/delaunay-tracked.rst
+++ b/doc/news/delaunay-tracked.rst
@@ -1,0 +1,6 @@
+**Added:**
+
+* Added a copy constructor, a copy assignment operator, a move constructor, and
+  a move assignment operator for a `Deformation`.
+* Implemented special handling of a `Tracked<Deformation>` so that it can track
+  flips in the tracked triangulation.

--- a/libflatsurf/flatsurf/cppyy.hpp
+++ b/libflatsurf/flatsurf/cppyy.hpp
@@ -83,6 +83,20 @@ std::optional<Deformation<FlatTriangulation<T>>> isomorphism(const FlatTriangula
       filter_map);
 }
 
+// cppyy has trouble with complex std::function parameters so we simplify the
+// interface of Tracked::Tracked to take away all qualifiers and most commas.
+template <typename T>
+Tracked<T> track(const FlatTriangulationCombinatorial& surface, T value) {
+  return Tracked<T>(surface, std::move(value));
+}
+
+// Extract the value of a Tracked<T>.
+// There seems to be no immediate way to call the operator* in cppyy.
+template <typename T>
+const T& unwrapTracked(const Tracked<T>& tracked) {
+  return tracked;
+}
+
 // Work around https://github.com/wlav/cppyy/issues/19 by removing std::forward
 // from the converting constructor of Vector.
 namespace cppyy {

--- a/libflatsurf/flatsurf/deformation.hpp
+++ b/libflatsurf/flatsurf/deformation.hpp
@@ -43,6 +43,11 @@ class Deformation {
   // Create the identical deformation.
   explicit Deformation(const Surface&);
 
+  // Create a copy of this deformation.
+  Deformation(const Deformation&);
+
+  Deformation(Deformation&&);
+
   // Return the image of the half edge under the deformation.
   [[deprecated("Use operator(Path) instead")]] std::optional<HalfEdge> operator()(HalfEdge) const;
 
@@ -62,6 +67,10 @@ class Deformation {
   const Surface& domain() const;
 
   const Surface& codomain() const;
+
+  Deformation& operator=(const Deformation&);
+
+  Deformation& operator=(Deformation&&);
 
   // Return whether this is a total map of topological spaces.
   bool total() const;

--- a/libflatsurf/src/deformation.cc
+++ b/libflatsurf/src/deformation.cc
@@ -32,6 +32,12 @@
 namespace flatsurf {
 
 template <typename Surface>
+Deformation<Surface>::Deformation(const Deformation& deformation) : Deformation(PrivateConstructor{}, deformation.self->relation->clone()) {}
+
+template <typename Surface>
+Deformation<Surface>::Deformation(Deformation&& deformation) : Deformation(PrivateConstructor{}, std::move(deformation.self->relation)) {}
+
+template <typename Surface>
 Deformation<Surface>::Deformation(Surface&& surface) :
   Deformation(surface) {}
 
@@ -57,6 +63,19 @@ const Surface& Deformation<Surface>::domain() const {
 template <typename Surface>
 const Surface& Deformation<Surface>::codomain() const {
   return self->relation->codomain;
+}
+
+
+template <typename Surface>
+Deformation<Surface>& Deformation<Surface>::operator=(const Deformation& deformation) {
+  self->relation = deformation.self->relation->clone();
+  return *this;
+}
+
+template <typename Surface>
+Deformation<Surface>& Deformation<Surface>::operator=(Deformation&& deformation) {
+  self->relation = std::move(deformation.self->relation);
+  return *this;
 }
 
 template <typename Surface>

--- a/libflatsurf/test/Makefile.am
+++ b/libflatsurf/test/Makefile.am
@@ -4,6 +4,7 @@ check_PROGRAMS =                        \
   cereal.test                           \
   chain.test                            \
   contour_decomposition.test            \
+  deformation.test                      \
   edge.test                             \
   flat_triangulation.test               \
   flat_triangulation_collapsed.test     \
@@ -27,6 +28,7 @@ bound_test_SOURCES = bound.test.cc main.cc
 cereal_test_SOURCES = cereal.test.cc cereal.helpers.hpp main.cc
 chain_test_SOURCES = chain.test.cc main.cc
 contour_decomposition_test_SOURCES = contour_decomposition.test.cc main.cc
+deformation_test_SOURCES = deformation.test.cc main.cc
 flat_triangulation_test_SOURCES = flat_triangulation.test.cc main.cc
 flat_triangulation_collapsed_test_SOURCES = flat_triangulation_collapsed.test.cc main.cc
 flat_triangulation_combinatorial_test_SOURCES = flat_triangulation_combinatorial.test.cc main.cc

--- a/libflatsurf/test/deformation.test.cc
+++ b/libflatsurf/test/deformation.test.cc
@@ -20,6 +20,8 @@
 #include <exact-real/element.hpp>
 
 #include "../flatsurf/deformation.hpp"
+#include "../flatsurf/edge.hpp"
+#include "../flatsurf/tracked.hpp"
 
 #include "external/catch2/single_include/catch2/catch.hpp"
 #include "generators/surface_generator.hpp"
@@ -40,6 +42,24 @@ TEMPLATE_TEST_CASE("Deformations", "[deformation]", (long long), (mpq_class), (r
 
     auto move = std::move(trivial);
     trivial = std::move(move);
+  }
+
+  SECTION("Trivial Deformations Follow Flips") {
+    const auto domain = surface->clone();
+    auto track = Tracked(*surface, Deformation(domain));
+
+    for (auto edge : surface->edges()) {
+      if (surface->convex(edge.positive(), true))
+        surface->flip(edge.positive());
+    }
+
+    REQUIRE(track->domain() == domain);
+    REQUIRE(track->codomain() == *surface);
+
+    surface->delaunay();
+
+    REQUIRE(track->domain() == domain);
+    REQUIRE(track->codomain() == *surface);
   }
 }
 

--- a/libflatsurf/test/deformation.test.cc
+++ b/libflatsurf/test/deformation.test.cc
@@ -1,0 +1,46 @@
+/**********************************************************************
+ *  This file is part of flatsurf.
+ *
+ *        Copyright (C) 2021 Julian Rüth
+ *
+ *  Flatsurf is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Flatsurf is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with flatsurf. If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************/
+
+#include <exact-real/element.hpp>
+
+#include "../flatsurf/deformation.hpp"
+
+#include "external/catch2/single_include/catch2/catch.hpp"
+#include "generators/surface_generator.hpp"
+
+namespace flatsurf::test {
+
+TEMPLATE_TEST_CASE("Deformations", "[deformation]", (long long), (mpq_class), (renf_elem_class), (exactreal::Element<exactreal::IntegerRing>), (exactreal::Element<exactreal::NumberField>)) {
+  using T = TestType;
+
+  const auto [name, surface_] = GENERATE(makeSurface<T>());
+  const auto surface = *surface_;
+  CAPTURE(*name, *surface);
+
+  SECTION("Deformations can be Copied and Moved") {
+    auto trivial = Deformation(*surface);
+    auto copy = trivial;
+    trivial = copy;
+
+    auto move = std::move(trivial);
+    trivial = std::move(move);
+  }
+}
+
+}

--- a/libflatsurf/test/saddle_connection.test.cc
+++ b/libflatsurf/test/saddle_connection.test.cc
@@ -28,8 +28,6 @@
 
 namespace flatsurf::test {
 
-using namespace flatsurf;
-
 TEMPLATE_TEST_CASE("Angle between Saddle Connections", "[saddle_connection][angle]", (long long), (mpq_class), (renf_elem_class), (exactreal::Element<exactreal::IntegerRing>), (exactreal::Element<exactreal::NumberField>)) {
   using T = TestType;
   using Surface = FlatTriangulation<T>;

--- a/pyflatsurf/src/pyflatsurf/cppyy_flatsurf.py
+++ b/pyflatsurf/src/pyflatsurf/cppyy_flatsurf.py
@@ -95,9 +95,14 @@ def decomposeFlowComponent(self, *args):
 
 cppyy.py.add_pythonization(filtered(re.compile("FlowComponent<.*>"))(add_method("decompose")(decomposeFlowComponent)), "flatsurf")
 
-# We have to workaround issues with complex std::function parameters in cppyy
-cppyy.py.add_pythonization(filtered(re.compile("FlatTriangulation<.*>"))(add_method("isomorphism")(lambda self, other, kind=None, filter_matrix=lambda a,b,c,d: a == 1 and b == 0 and c == 0 and d == 1, filter_map=lambda a, b: True: cppyy.gbl.flatsurf.isomorphism[type(self).Coordinate.__cpp_name__](self, other, kind or cppyy.gbl.flatsurf.ISOMORPHISM.FACES, lambda m: filter_matrix(m.a, m.b, m.c, m.d), filter_map))), "flatsurf")
+# Make the value underlying a Tracked<T> accessible.
+def unwrapTracked(self):
+    from cppyy.gbl import flatsurf
+    return flatsurf.unwrapTracked(self)
+cppyy.py.add_pythonization(filtered(re.compile("Tracked<.*>"))(add_method("value")(unwrapTracked)), "flatsurf")
 
+# We have to work around issues with complex std::function parameters in cppyy
+cppyy.py.add_pythonization(filtered(re.compile("FlatTriangulation<.*>"))(add_method("isomorphism")(lambda self, other, kind=None, filter_matrix=lambda a,b,c,d: a == 1 and b == 0 and c == 0 and d == 1, filter_map=lambda a, b: True: cppyy.gbl.flatsurf.isomorphism[type(self).Coordinate.__cpp_name__](self, other, kind or cppyy.gbl.flatsurf.ISOMORPHISM.FACES, lambda m: filter_matrix(m.a, m.b, m.c, m.d), filter_map))), "flatsurf")
 
 for path in os.environ.get('PYFLATSURF_INCLUDE','').split(':'):
     if path: cppyy.add_include_path(path)
@@ -110,3 +115,6 @@ from cppyy.gbl import flatsurf
 # Work around https://github.com/wlav/cppyy/issues/19
 cppyy.gbl.flatsurf.cppyy.Vector._unwrapped = cppyy.gbl.flatsurf.Vector
 cppyy.gbl.flatsurf.Vector = cppyy.gbl.flatsurf.cppyy.Vector
+
+# Work around issues with complex std::function parameters in cppyy
+flatsurf.Tracked = cppyy.gbl.flatsurf.track

--- a/pyflatsurf/src/pyflatsurf/cppyy_flatsurf.py
+++ b/pyflatsurf/src/pyflatsurf/cppyy_flatsurf.py
@@ -72,7 +72,6 @@ cppyy.py.add_pythonization(filtered(re.compile("SaddleConnectionsByLength<.*>"))
 # We cannot create an OddHalfEdgeMap directly due to https://bitbucket.org/wlav/cppyy/issues/273/segfault-in-cpycppyy-anonymous-namespace
 cppyy.py.add_pythonization(filtered(re.compile("FlatTriangulation<.*>"))(wrap_method("__add__")(lambda self, cpp, rhs: cpp(cppyy.gbl.flatsurf.makeOddHalfEdgeMap[cppyy.gbl.flatsurf.Vector._unwrapped[type(self).Coordinate]](self.combinatorial(), rhs)))), "flatsurf")
 
-
 cppyy.py.add_pythonization(filtered(re.compile("FlowDecomposition<.*>"))(add_method("cylinders")(lambda self: [component for component in self.components() if component.cylinder()])), "flatsurf")
 cppyy.py.add_pythonization(filtered(re.compile("FlowDecomposition<.*>"))(add_method("minimalComponents")(lambda self: [component for component in self.components() if component.withoutPeriodicTrajectory()])), "flatsurf")
 cppyy.py.add_pythonization(filtered(re.compile("FlowDecomposition<.*>"))(add_method("undeterminedComponents")(lambda self: [component for component in self.components() if not (component.cylinder() == True) and not (component.withoutPeriodicTrajectory() == True)])), "flatsurf")

--- a/pyflatsurf/test/Makefile.am
+++ b/pyflatsurf/test/Makefile.am
@@ -1,7 +1,7 @@
 if HAVE_SAGE
   MAYBE_SAGE = sage-doctest.sh flow_decomposition.py
 endif
-TESTS = flat_triangulation.py half_edge.py saddle_connections.py vector_renf_elem.py vector_gmp.py python-doctest.sh $(MAYBE_SAGE)
+TESTS = deformation.py flat_triangulation.py half_edge.py saddle_connections.py vector_renf_elem.py vector_gmp.py python-doctest.sh $(MAYBE_SAGE)
 EXTRA_DIST = $(TESTS) surfaces.py
 
 AM_TESTS_ENVIRONMENT = . $(builddir)/test-env.sh;
@@ -11,6 +11,7 @@ flat_triangulation.py: test-env.sh surfaces.py
 saddle_connections.py: test-env.sh surfaces.py
 vector_renf_elem.py: test-env.sh surfaces.py
 vector_gmp.py: test-env.sh
+deformation.py: test-env.sh surfaces.py
 python-doctest.sh: test-env.sh
 sage-doctest.sh: test-env.sh
 

--- a/pyflatsurf/test/deformation.py
+++ b/pyflatsurf/test/deformation.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+
+######################################################################
+# This file is part of flatsurf.
+#
+#       Copyright (C) 2019-2021 Julian Rüth
+#
+# flatsurf is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# flatsurf is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with flatsurf. If not, see <https://www.gnu.org/licenses/>.
+######################################################################
+
+import sys
+import pytest
+import ctypes
+
+from pyflatsurf import flatsurf
+import surfaces
+
+def test_deformation_square(capsys):
+    Edge = flatsurf.Edge
+
+    vector = flatsurf.Vector['mpq_class']
+
+    # A square of size (3, 3)
+    square = surfaces.square(vector).scale(3)
+
+    # Insert an extra vertex at (2, 1) that is easier to move around without
+    # having to change the entire surface.
+    square = square.insertAt(flatsurf.HalfEdge(1), vector(2, 1)).surface()
+
+    # A forbidden shift, collapsing a half edge during the shift; this is
+    # supposed to fail but it should fail silently.
+    shift = lambda e: vector(-2, -4) if e in [Edge(4), Edge(5), Edge(6)] else vector(0, 0)
+
+    capsys.readouterr()
+
+    import cppyy
+    with pytest.raises(cppyy.gbl.std.invalid_argument):
+        square + [shift(e) for e in square.edges()]
+
+    # Verify that #179 has been fixed, i.e., no warnings are printed
+    output = capsys.readouterr()
+    assert output.out == ""
+    assert output.err == ""
+
+    # A much smaller shift in the same direction is allowed
+    square + [shift(e) / 128 for e in square.edges()]
+
+    # A shift half the length collapses the extra vertex
+    square + [shift(e) / 2 for e in square.edges()]
+
+    # Another shift with a vertex ending up on the interior of a half edge, i.e., requires a flip.
+    shift = lambda e: vector(-1, 0) if e in [Edge(4), Edge(5), Edge(6)] else vector(0, 0)
+    square + [shift(e) for e in square.edges()]
+
+    # Another shift with a vertex crossing over the interior of a half edge, i.e., requires a flip.
+    shift = lambda e: vector(-2, 0) if e in [Edge(4), Edge(5), Edge(6)] else vector(0, 0)
+    square + [shift(e) for e in square.edges()]
+
+    # Another shift with a vertex crossing over the interior of a half edge but
+    # then ending up on another vertex, i.e., requires a flip and a collapse.
+    shift = lambda e: vector(-4, -2) if e in [Edge(4), Edge(5), Edge(6)] else vector(0, 0)
+    square + [shift(e) for e in square.edges()]
+
+    # Another shift with a vertex crossing lots of half edges, i.e., requiring many flips.
+    shift = lambda e: vector(-23, 0) if e in [Edge(4), Edge(5), Edge(6)] else vector(0, 0)
+    square + [shift(e) for e in square.edges()]
+
+    # Insert a vertex in the other triangle so we can move both simultaneously
+    square = square.insertAt(flatsurf.HalfEdge(3), vector(1, 2)).surface()
+
+    # Shift both inserted vertices towards the same vertex simultaneously
+    shift = lambda e: vector(-1, -2) if e in [Edge(4), Edge(5), Edge(6)] else vector(-2, -1) if e in [Edge(7), Edge(8), Edge(9)] else vector(0, 0)
+    square + [shift(e) / 2 for e in square.edges()]
+
+    # Shift both inserted vertices onto the same vertex simultaneously
+    square + [shift(e) for e in square.edges()]
+
+    # Shift both inserted vertices a long way across the surface in the same direction
+    shift = lambda e: vector(-23, 0) if e in [Edge(4), Edge(5), Edge(6)] else vector(-23, 0) if e in [Edge(7), Edge(8), Edge(9)] else vector(0, 0)
+    square + [shift(e) for e in square.edges()]
+
+    # Shift both inserted vertices a long way across the surface in different directions (invalid because it the two marked vertices meet at some point.)
+    shift = lambda e: vector(-23, 0) if e in [Edge(4), Edge(5), Edge(6)] else vector(0, -23) if e in [Edge(7), Edge(8), Edge(9)] else vector(0, 0)
+    with pytest.raises(cppyy.gbl.std.invalid_argument):
+        square + [shift(e) for e in square.edges()]
+
+    # Shift both inserted vertices a long way across the surface in different directions
+    shift = lambda e: vector(-23, 0) if e in [Edge(4), Edge(5), Edge(6)] else vector(-1, -23) if e in [Edge(7), Edge(8), Edge(9)] else vector(0, 0)
+    square + [shift(e) for e in square.edges()]
+
+    # Shift both inserted vertices a long way across the surface in different directions and at different velocities
+    shift = lambda e: vector(-23, 0) if e in [Edge(4), Edge(5), Edge(6)] else vector(0, -47) if e in [Edge(7), Edge(8), Edge(9)] else vector(0, 0)
+    square + [shift(e) for e in square.edges()]
+
+def test_deformation_L():
+    vector = flatsurf.Vector['mpq_class']
+
+    L = surfaces.L(vector)
+    
+    # Deform the L by doubling each vector
+    L + [L.fromHalfEdge(e.positive()) for e in L.edges()]
+
+def test_deform_hexagon():
+    hexagon = surfaces.random_hexagon(flatsurf.Vector['exactreal::Element<exactreal::NumberField>'])
+
+    # Deform the hexagon by doubling each vector
+    hexagon + [hexagon.fromHalfEdge(e.positive()) for e in hexagon.edges()]
+
+    # Deform the hexagon by adding another random hexagon
+    hexagon_ = surfaces.random_hexagon(flatsurf.Vector['exactreal::Element<exactreal::NumberField>'])
+    hexagon + [hexagon_.fromHalfEdge(e.positive()) for e in hexagon.edges()]
+
+@pytest.mark.parametrize("surface", surfaces.surfaces(), ids=surfaces.name)
+def test_deformation(surface):
+    import cppyy
+    domain = surface.clone()
+    track = cppyy.gbl.flatsurf.Tracked(surface.combinatorial(), cppyy.gbl.flatsurf.Deformation[type(surface)](domain))
+
+    for edge in surface.edges():
+        if surface.convex(edge.positive(), True):
+            surface.flip(edge.positive())
+
+    assert track.domain() == domain
+    assert track.codomain() == surface
+
+    surface.delaunay()
+
+    assert track.domain() == domain
+    assert track.codomain() == surface
+
+if __name__ == '__main__': sys.exit(pytest.main(sys.argv))

--- a/pyflatsurf/test/flat_triangulation.py
+++ b/pyflatsurf/test/flat_triangulation.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 ######################################################################
 # This file is part of flatsurf.
 #
-#       Copyright (C) 2020 Julian Rüth
+#       Copyright (C) 2020-2021 Julian Rüth
 #
 # flatsurf is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -27,8 +25,6 @@ import cppyy
 from pyflatsurf import flatsurf
 import surfaces
 
-Edge = flatsurf.Edge
-
 def test_addition():
     vector = flatsurf.Vector['mpq_class']
 
@@ -41,99 +37,6 @@ def test_addition():
     for halfEdge in L.halfEdges():
         assert L.fromHalfEdge(halfEdge).y() != 1
 
-
-def test_deformation_square(capsys):
-    vector = flatsurf.Vector['mpq_class']
-
-    # A square of size (3, 3)
-    square = surfaces.square(vector).scale(3)
-
-    # Insert an extra vertex at (2, 1) that is easier to move around without
-    # having to change the entire surface.
-    square = square.insertAt(flatsurf.HalfEdge(1), vector(2, 1)).surface()
-
-    # A forbidden shift, collapsing a half edge during the shift; this is
-    # supposed to fail but it should fail silently.
-    shift = lambda e: vector(-2, -4) if e in [Edge(4), Edge(5), Edge(6)] else vector(0, 0)
-
-    capsys.readouterr()
-
-    with pytest.raises(cppyy.gbl.std.invalid_argument):
-        square + [shift(e) for e in square.edges()]
-
-    # Verify that #179 has been fixed, i.e., no warnings are printed
-    output = capsys.readouterr()
-    assert output.out == ""
-    assert output.err == ""
-
-    # A much smaller shift in the same direction is allowed
-    square + [shift(e) / 128 for e in square.edges()]
-
-    # A shift half the length collapses the extra vertex
-    square + [shift(e) / 2 for e in square.edges()]
-
-    # Another shift with a vertex ending up on the interior of a half edge, i.e., requires a flip.
-    shift = lambda e: vector(-1, 0) if e in [Edge(4), Edge(5), Edge(6)] else vector(0, 0)
-    square + [shift(e) for e in square.edges()]
-
-    # Another shift with a vertex crossing over the interior of a half edge, i.e., requires a flip.
-    shift = lambda e: vector(-2, 0) if e in [Edge(4), Edge(5), Edge(6)] else vector(0, 0)
-    square + [shift(e) for e in square.edges()]
-
-    # Another shift with a vertex crossing over the interior of a half edge but
-    # then ending up on another vertex, i.e., requires a flip and a collapse.
-    shift = lambda e: vector(-4, -2) if e in [Edge(4), Edge(5), Edge(6)] else vector(0, 0)
-    square + [shift(e) for e in square.edges()]
-
-    # Another shift with a vertex crossing lots of half edges, i.e., requiring many flips.
-    shift = lambda e: vector(-23, 0) if e in [Edge(4), Edge(5), Edge(6)] else vector(0, 0)
-    square + [shift(e) for e in square.edges()]
-
-    # Insert a vertex in the other triangle so we can move both simultaneously
-    square = square.insertAt(flatsurf.HalfEdge(3), vector(1, 2)).surface()
-
-    # Shift both inserted vertices towards the same vertex simultaneously
-    shift = lambda e: vector(-1, -2) if e in [Edge(4), Edge(5), Edge(6)] else vector(-2, -1) if e in [Edge(7), Edge(8), Edge(9)] else vector(0, 0)
-    square + [shift(e) / 2 for e in square.edges()]
-
-    # Shift both inserted vertices onto the same vertex simultaneously
-    square + [shift(e) for e in square.edges()]
-
-    # Shift both inserted vertices a long way across the surface in the same direction
-    shift = lambda e: vector(-23, 0) if e in [Edge(4), Edge(5), Edge(6)] else vector(-23, 0) if e in [Edge(7), Edge(8), Edge(9)] else vector(0, 0)
-    square + [shift(e) for e in square.edges()]
-
-    # Shift both inserted vertices a long way across the surface in different directions (invalid because it the two marked vertices meet at some point.)
-    shift = lambda e: vector(-23, 0) if e in [Edge(4), Edge(5), Edge(6)] else vector(0, -23) if e in [Edge(7), Edge(8), Edge(9)] else vector(0, 0)
-    with pytest.raises(cppyy.gbl.std.invalid_argument):
-        square + [shift(e) for e in square.edges()]
-
-    # Shift both inserted vertices a long way across the surface in different directions
-    shift = lambda e: vector(-23, 0) if e in [Edge(4), Edge(5), Edge(6)] else vector(-1, -23) if e in [Edge(7), Edge(8), Edge(9)] else vector(0, 0)
-    square + [shift(e) for e in square.edges()]
-
-    # Shift both inserted vertices a long way across the surface in different directions and at different velocities
-    shift = lambda e: vector(-23, 0) if e in [Edge(4), Edge(5), Edge(6)] else vector(0, -47) if e in [Edge(7), Edge(8), Edge(9)] else vector(0, 0)
-    square + [shift(e) for e in square.edges()]
-
-def test_deformation_L():
-    vector = flatsurf.Vector['mpq_class']
-
-    L = surfaces.L(vector)
-    
-    # Deform the L by doubling each vector
-    L + [L.fromHalfEdge(e.positive()) for e in L.edges()]
-
-def test_deform_hexagon():
-    hexagon = surfaces.random_hexagon()
-
-    # Deform the hexagon by doubling each vector
-    hexagon + [hexagon.fromHalfEdge(e.positive()) for e in hexagon.edges()]
-
-    # Deform the hexagon by adding another random hexagon
-    hexagon_ = surfaces.random_hexagon()
-    hexagon + [hexagon_.fromHalfEdge(e.positive()) for e in hexagon.edges()]
-
 def test_isomorphism():
     vector = flatsurf.Vector['mpq_class']
     L = surfaces.L(vector)
@@ -142,7 +45,7 @@ def test_isomorphism():
     assert not L.isomorphism(L, filter_matrix=lambda a, b, c, d: a*d - b*c not in [-1, 1])
 
 def test_serialization():
-    hexagon = surfaces.random_hexagon()
+    hexagon = surfaces.random_hexagon(flatsurf.Vector['exactreal::Element<exactreal::NumberField>'])
 
     from pickle import loads, dumps
     assert loads(dumps(hexagon)) == hexagon

--- a/pyflatsurf/test/flow_decomposition.py
+++ b/pyflatsurf/test/flow_decomposition.py
@@ -27,7 +27,7 @@ from pyflatsurf import flatsurf
 import surfaces
 
 def test_hexagon_eantic():
-    surface = surfaces.hexagon()
+    surface = surfaces.hexagon(flatsurf.Vector['eantic::renf_elem_class'])
     decompositions = {(1, 0): 0, (2, 0): 0}
 
     for connection in surface.connections().bound(16).sector(flatsurf.HalfEdge(1)):
@@ -79,7 +79,7 @@ def test_hexagon_eantic():
     assert decompositions == {(1, 0): 7, (2, 0): 3}
 
 def test_D33():
-    S = surfaces.D33()
+    S = surfaces.D33(flatsurf.Vector['eantic::renf_elem_class'])
     decompositions = {(2, 0): 0, (3, 0): 0, (0, 2): 0}
     for connection in S.connections().bound(4):
         v = connection.vector()
@@ -119,7 +119,7 @@ def test_D33():
 
 
 def test_undetermined():
-    S = surfaces.D33()
+    S = surfaces.D33(flatsurf.Vector['eantic::renf_elem_class'])
 
     R2 = flatsurf.Vector['eantic::renf_elem_class']
     decomposition = flatsurf.makeFlowDecomposition(S, R2(135, 17))

--- a/pyflatsurf/test/saddle_connections.py
+++ b/pyflatsurf/test/saddle_connections.py
@@ -72,7 +72,7 @@ def test_L_with_slit_mpq():
     assert len([1 for c in connections]) == 15
 
 def test_hexagon_eantic():
-    surface = surfaces.hexagon(flatsurf.Vector['exactreal::Element<exactreal::NumberField>'])
+    surface = surfaces.hexagon(flatsurf.Vector['eantic::renf_elem_class'])
     connections = surface.connections().bound(16).sector(flatsurf.HalfEdge(1))
     assert len([1 for c in connections]) == 10
 

--- a/pyflatsurf/test/saddle_connections.py
+++ b/pyflatsurf/test/saddle_connections.py
@@ -72,15 +72,9 @@ def test_L_with_slit_mpq():
     assert len([1 for c in connections]) == 15
 
 def test_hexagon_eantic():
-    surface = surfaces.hexagon()
+    surface = surfaces.hexagon(flatsurf.Vector['exactreal::Element<exactreal::NumberField>'])
     connections = surface.connections().bound(16).sector(flatsurf.HalfEdge(1))
     assert len([1 for c in connections]) == 10
-
-def test_hexagon_exactreal():
-    from pyexactreal import exactreal
-    surface = surfaces.random_hexagon()
-    connections = surface.connections().bound(16).sector(flatsurf.HalfEdge(1))
-    assert len([1 for c in connections]) >= 10
 
 def test_printing():
     for coefficients in ['long long', 'mpz_class', 'mpq_class', 'eantic::renf_elem_class', 'exactreal::Element<exactreal::IntegerRing>', 'exactreal::Element<exactreal::RationalField>', 'exactreal::Element<exactreal::NumberField>']:

--- a/pyflatsurf/test/surfaces.py
+++ b/pyflatsurf/test/surfaces.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 ######################################################################
 # This file is part of flatsurf.
 #
-#       Copyright (C) 2019 Julian Rüth
+#       Copyright (C) 2019-2021 Julian Rüth
 #
 # flatsurf is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -25,7 +24,7 @@ from pyexactreal import exactreal
 from pyeantic import eantic
 
 # The number field has to live out here and not be a local variable in the
-# methods as it would be destroyed by the garbage collector otherwise
+# methods as they would be destroyed by the garbage collector otherwise
 # (segfault.) Eventually we want renf_class/Module to use shared_ptr here. Then
 # this won't be a problem anymore.
 K = eantic.renf_class.make("x^2 - 3", "x", "1.73 +/- 0.1")
@@ -41,18 +40,17 @@ def L(R2):
     vertices = [[1, 2, 3, 4, 5, -3, 6, 7, 8, -6, -2, 9, -4, -5, -9, -1, -7, -8]]
     return Surface(vertices, vectors)
 
-def hexagon():
-    R2 = flatsurf.Vector['eantic::renf_elem_class']
+def hexagon(R2, R=None):
     x = K.gen()
-    R = eantic.renf_elem
+    if R is None:
+        R = R2.Coordinate
     vectors = [R2(R(K, 2), R(K, 0)), R2(R(K, 1), x), R2(R(K, 3), x), R2(R(K, 1), -x), R2(R(K, 4), R(K, 0)), R2(R(K, 3), x)]
     vertices = [[1, 3, -4, -5, -3, -2], [2, -1, -6, 4, 5, 6]]
     return Surface(vertices, vectors)
 
-def random_hexagon():
+def random_hexagon(R2):
     x = K.gen()
     M = NumberFieldModule(K, RealNumber.rational(1), RealNumber.random(), RealNumber.random())
-    R2 = flatsurf.Vector['exactreal::Element<exactreal::NumberField>']
     # The side lengths are going to be 2, 2·μ, 2·ν where μ,ν are the random parameters of M.
     one = M.gen(0)
     μ = M.gen(1)
@@ -65,9 +63,9 @@ def random_hexagon():
     vertices = [[1, 3, -4, -5, -3, -2], [2, -1, -6, 4, 5, 6]]
     return Surface(vertices, vectors)
 
-def D33():
-    R2 = flatsurf.Vector['eantic::renf_elem_class']
-    R = eantic.renf_elem
+def D33(R2, R=None):
+    if R is None:
+        R = R2.Coordinate
     zero = R(O, 0)
     one = R(O, 1)
     two = R(O, 2)
@@ -83,3 +81,50 @@ def D33():
     vertices = [[1, -3, 5, -4, 9, -8, 10, -12, 11, -10, 6, -5],
                 [3, -2, 4, -6, 8, -7, 12, -11, 7, -9, 2, -1]]
     return Surface(vertices, vectors)
+
+def surfaces(T=None):
+    if T is None: 
+        for T in ['long long', 'mpz_class', 'mpq_class', 'eantic::renf_elem_class', 'exactreal::Element<exactreal::IntegerRing>', 'exactreal::Element<exactreal::RationalField>', 'exactreal::Element<exactreal::NumberField>']:
+            for surface in surfaces(T):
+                yield surface
+    else:
+        R2 = flatsurf.Vector[T]
+
+        import cppyy
+
+        surface = square(R2)
+        surface.name = f"Square[{T}]"
+        yield surface
+
+        surface = L(R2)
+        surface.name = f"L[{T}]"
+        yield surface
+
+        if R2 == flatsurf.Vector['long long']:
+            pass
+        elif R2 == flatsurf.Vector[cppyy.gbl.mpz_class]:
+            pass
+        elif R2 == flatsurf.Vector[cppyy.gbl.mpq_class]:
+            pass
+        elif R2 == flatsurf.Vector[cppyy.gbl.exactreal.Element[cppyy.gbl.exactreal.IntegerRing]]:
+            pass
+        elif R2 == flatsurf.Vector[cppyy.gbl.exactreal.Element[cppyy.gbl.exactreal.RationalField]]:
+            pass
+        elif R2 == flatsurf.Vector[cppyy.gbl.eantic.renf_elem_class]:
+            surface = hexagon(R2, R=eantic.renf_elem)
+            surface.name = f"Hexagon[{T}]"
+            yield surface
+
+            surface = D33(R2, R=eantic.renf_elem)
+            surface.name = f"D33[{T}]"
+            yield surface
+            pass
+        elif R2 == flatsurf.Vector[cppyy.gbl.exactreal.Element[cppyy.gbl.exactreal.NumberField]]:
+            surface = random_hexagon(R2)
+            surface.name = f"Hexagon[{T}]"
+            yield surface
+        else:
+            raise TypeError(R2)
+
+def name(surface):
+    return surface.name

--- a/pyflatsurf/test/surfaces.py
+++ b/pyflatsurf/test/surfaces.py
@@ -22,6 +22,7 @@ from pyexactreal import RealNumber, NumberFieldModule
 import pyexactreal
 from pyexactreal import exactreal
 from pyeantic import eantic
+import cppyy
 
 # The number field has to live out here and not be a local variable in the
 # methods as they would be destroyed by the garbage collector otherwise
@@ -40,10 +41,11 @@ def L(R2):
     vertices = [[1, 2, 3, 4, 5, -3, 6, 7, 8, -6, -2, 9, -4, -5, -9, -1, -7, -8]]
     return Surface(vertices, vectors)
 
-def hexagon(R2, R=None):
+def hexagon(R2):
     x = K.gen()
-    if R is None:
-        R = R2.Coordinate
+    R = R2.Coordinate
+    if R2 == flatsurf.Vector[cppyy.gbl.eantic.renf_elem_class]:
+        R = eantic.renf_elem
     vectors = [R2(R(K, 2), R(K, 0)), R2(R(K, 1), x), R2(R(K, 3), x), R2(R(K, 1), -x), R2(R(K, 4), R(K, 0)), R2(R(K, 3), x)]
     vertices = [[1, 3, -4, -5, -3, -2], [2, -1, -6, 4, 5, 6]]
     return Surface(vertices, vectors)
@@ -63,9 +65,10 @@ def random_hexagon(R2):
     vertices = [[1, 3, -4, -5, -3, -2], [2, -1, -6, 4, 5, 6]]
     return Surface(vertices, vectors)
 
-def D33(R2, R=None):
-    if R is None:
-        R = R2.Coordinate
+def D33(R2):
+    R = R2.Coordinate
+    if R2 == flatsurf.Vector[cppyy.gbl.eantic.renf_elem_class]:
+        R = eantic.renf_elem
     zero = R(O, 0)
     one = R(O, 1)
     two = R(O, 2)
@@ -90,8 +93,6 @@ def surfaces(T=None):
     else:
         R2 = flatsurf.Vector[T]
 
-        import cppyy
-
         surface = square(R2)
         surface.name = f"Square[{T}]"
         yield surface
@@ -111,11 +112,11 @@ def surfaces(T=None):
         elif R2 == flatsurf.Vector[cppyy.gbl.exactreal.Element[cppyy.gbl.exactreal.RationalField]]:
             pass
         elif R2 == flatsurf.Vector[cppyy.gbl.eantic.renf_elem_class]:
-            surface = hexagon(R2, R=eantic.renf_elem)
+            surface = hexagon(R2)
             surface.name = f"Hexagon[{T}]"
             yield surface
 
-            surface = D33(R2, R=eantic.renf_elem)
+            surface = D33(R2)
             surface.name = f"D33[{T}]"
             yield surface
             pass

--- a/pyflatsurf/test/vector_renf_elem.py
+++ b/pyflatsurf/test/vector_renf_elem.py
@@ -29,7 +29,7 @@ from pyeantic import eantic
 import surfaces
 
 def test_printing():
-    surface = surfaces.hexagon()
+    surface = surfaces.hexagon(flatsurf.Vector['eantic::renf_elem_class'])
     assert str(surface.fromHalfEdge(flatsurf.HalfEdge(1))) == "(2, 0)"
     assert repr(surface.fromHalfEdge(flatsurf.HalfEdge(1))) == "(2, 0)"
 


### PR DESCRIPTION
so we can, e.g., relate saddle connections before and after a Delaunay retriangulation.