### PR TITLE
Drop expensive assertions when flipping an edge

### DIFF
--- a/doc/news/check.rst
+++ b/doc/news/check.rst
@@ -1,0 +1,3 @@
+**Performance:**
+
+* Remove redundant expensive assertions when Delaunay triangulating.

--- a/libflatsurf/src/flat_triangulation.cc
+++ b/libflatsurf/src/flat_triangulation.cc
@@ -1,7 +1,7 @@
 /**********************************************************************
  *  This file is part of flatsurf.
  *
- *        Copyright (C) 2019-2021 Julian Rüth
+ *        Copyright (C) 2019-2022 Julian Rüth
  *
  *  Flatsurf is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -997,8 +997,6 @@ void ImplementationOf<FlatTriangulation<T>>::flip(HalfEdge e) {
   LIBFLATSURF_CHECK_ARGUMENT(self.convex(e, true), "cannot flip this edge as a resulting face would not be strictly convex");
 
   ImplementationOf<FlatTriangulationCombinatorial>::flip(e);
-
-  check();
 }
 
 template <typename T>


### PR DESCRIPTION
on large surfaces this global assertions is more expensive than the actual flip.

In any case, since we already tested that the quadrilateral is convex, there is no point (anymore) in having this assertion.

Note that there are lots of tests/benchmarks for flipping and Delaunay triangulation already.