### PR TITLE
Actually run equivalence class tests in Python

### DIFF
--- a/doc/news/hashcode.rst
+++ b/doc/news/hashcode.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fixed missing implementation of hashing for `EquivalenceClass`.

--- a/doc/news/pycodes.rst
+++ b/doc/news/pycodes.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fixed equivalence tests in pyflatsurf test suite.

--- a/libflatsurf/src/equivalence_class.cc
+++ b/libflatsurf/src/equivalence_class.cc
@@ -58,13 +58,29 @@ ImplementationOf<EquivalenceClass<Surface>>::ImplementationOf(const Surface& sur
 }
 
 template <typename Surface>
+size_t ImplementationOf<EquivalenceClass<Surface>>::hash(const EquivalenceClass<Surface>& self) {
+  return self.self->code->hash();
+}
+
+template <typename Surface>
 std::ostream& operator<<(std::ostream& os, const EquivalenceClass<Surface>& clazz) {
   return os << "[" << clazz.representative() << "] identified by (" << *clazz.self->code << ")";
 }
 
 }
 
+namespace std {
+
+using namespace flatsurf;
+
+template <typename Surface>
+size_t hash<EquivalenceClass<Surface>>::operator()(const EquivalenceClass<Surface>& self) const {
+  return ImplementationOf<EquivalenceClass<Surface>>::hash(self);
+}
+
+}  // namespace std
+
 // Instantiations of templates so implementations are generated for the linker
 #include "util/instantiate.ipp"
 
-LIBFLATSURF_INSTANTIATE_MANY_WRAPPED((LIBFLATSURF_INSTANTIATE_WITH_IMPLEMENTATION), EquivalenceClass, LIBFLATSURF_FLAT_TRIANGULATION_TYPES)
+LIBFLATSURF_INSTANTIATE_MANY_WRAPPED((LIBFLATSURF_INSTANTIATE_WITH_IMPLEMENTATION)(LIBFLATSURF_INSTANTIATE_HASH), EquivalenceClass, LIBFLATSURF_FLAT_TRIANGULATION_TYPES)

--- a/libflatsurf/src/impl/equivalence_class.impl.hpp
+++ b/libflatsurf/src/impl/equivalence_class.impl.hpp
@@ -37,6 +37,10 @@ class ImplementationOf<EquivalenceClass<Surface>> {
   ReadOnly<Equivalence<Surface>> equivalence;
   std::shared_ptr<EquivalenceClassCode> code;
   size_t automorphisms;
+
+  static size_t hash(const EquivalenceClass<Surface>&);
+
+  friend std::hash<EquivalenceClass<Surface>>;
 };
 
 }

--- a/libflatsurf/test/equivalence_class.test.cc
+++ b/libflatsurf/test/equivalence_class.test.cc
@@ -102,4 +102,20 @@ TEMPLATE_TEST_CASE("Automorphisms of Surfaces", "[EquivalenceClass][automorphism
 
   REQUIRE(equivalenceClass.automorphisms() >= 1);
 }
+
+TEMPLATE_TEST_CASE("Equivalence Classes are Hashable", "[EquivalenceClass][hash]", (long long), (mpz_class), (mpq_class), (renf_elem_class), (exactreal::Element<exactreal::IntegerRing>), (exactreal::Element<exactreal::RationalField>), (exactreal::Element<exactreal::NumberField>)) {
+  using T = TestType;
+
+  const auto surface = GENERATE_SURFACES(T);
+  CAPTURE(surface);
+
+  const auto& equivalence = GENERATE_REF(equivalences(surface));
+  CAPTURE(equivalence);
+
+  const auto equivalenceClass = EquivalenceClass(*surface, equivalence);
+  CAPTURE(equivalenceClass);
+
+  REQUIRE(std::hash<EquivalenceClass<FlatTriangulation<T>>>{}(equivalenceClass) == std::hash<EquivalenceClass<FlatTriangulation<T>>>{}(EquivalenceClass(*surface, equivalence)));
+}
+
 }

--- a/pyflatsurf/test/bound.py
+++ b/pyflatsurf/test/bound.py
@@ -36,4 +36,3 @@ def test_bound():
     assert bound1 != bound64
 
 if __name__ == '__main__': sys.exit(pytest.main(sys.argv))
-

--- a/pyflatsurf/test/equivalence_class.py
+++ b/pyflatsurf/test/equivalence_class.py
@@ -3,7 +3,7 @@
 ######################################################################
 # This file is part of flatsurf.
 #
-#       Copyright (C) 2022 Julian Rüth
+#       Copyright (C) 2022-2023 Julian Rüth
 #
 # flatsurf is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,6 +19,9 @@
 # along with flatsurf. If not, see <https://www.gnu.org/licenses/>.
 ######################################################################
 
+import sys
+import pytest
+
 from pyflatsurf import flatsurf
 import surfaces
 
@@ -27,9 +30,12 @@ def test_equivalence_class():
     for coefficients in ['long long', 'mpz_class', 'mpq_class', 'eantic::renf_elem_class', 'exactreal::Element<exactreal::IntegerRing>', 'exactreal::Element<exactreal::RationalField>', 'exactreal::Element<exactreal::NumberField>']:
         square = surfaces.square(flatsurf.Vector[coefficients])
         l = surfaces.L(flatsurf.Vector[coefficients])
-        for equivalence in [flatsurf.Equivalence.combinatorial(), flatsurf.Equivalence.linear()]:
-            a = flatsurf.EquivalenceClass(square, equivalence)
-            b = flatsurf.EquivalenceClass(l, equivalence)
+        S = type(square)
+        for equivalence in [flatsurf.Equivalence[S].combinatorial(), flatsurf.Equivalence[S].linear()]:
+            a = flatsurf.EquivalenceClass[S](square, equivalence)
+            b = flatsurf.EquivalenceClass[S](l, equivalence)
 
             assert a != b
-            assert a == flatsurf.EquivalenceClass(square, equivalence)
+            assert a == flatsurf.EquivalenceClass[S](square, equivalence)
+
+if __name__ == '__main__': sys.exit(pytest.main(sys.argv))

--- a/pyflatsurf/test/equivalence_class.py
+++ b/pyflatsurf/test/equivalence_class.py
@@ -36,6 +36,8 @@ def test_equivalence_class():
             b = flatsurf.EquivalenceClass[S](l, equivalence)
 
             assert a != b
+            assert hash(a) != hash(b)
             assert a == flatsurf.EquivalenceClass[S](square, equivalence)
+            assert hash(a) == hash(flatsurf.EquivalenceClass[S](square, equivalence))
 
 if __name__ == '__main__': sys.exit(pytest.main(sys.argv))


### PR DESCRIPTION
and add the missing implementation of hash glue.